### PR TITLE
Change BCAL geometry parameters to dodge a change in interface

### DIFF
--- a/src/programs/Simulation/mcsmear/BCALSmearer.cc
+++ b/src/programs/Simulation/mcsmear/BCALSmearer.cc
@@ -441,9 +441,9 @@ void BCALSmearer::SimpleDarkHitsSmear(map<int, SumHits> &bcalfADC)
    double sigma4 = bcal_config->BCAL_LAYER4_SIGMA_SCALE*bcal_config->BCAL_MEV_PER_ADC_COUNT; 
 
    // Loop over all fADC readout cells
-   for(int imodule=1; imodule<=dBCALGeom->GetBCAL_Nmodules(); imodule++){
+   for(int imodule=1; imodule<=bcal_config->BCAL_NUM_MODULES; imodule++){
 
-      int n_layers = dBCALGeom->GetBCAL_Nlayers();
+      int n_layers = bcal_config->BCAL_NUM_LAYERS;
       for(int fADC_lay=1; fADC_lay<=n_layers; fADC_lay++){
          if(fADC_lay == 1) 
          	sigma = sigma1;
@@ -456,7 +456,7 @@ void BCALSmearer::SimpleDarkHitsSmear(map<int, SumHits> &bcalfADC)
 
 		 // there's a constant number of sectors now...
          //int n_sectors = (fADC_lay <= dBCALGeom->GetBCAL_NInnerLayers())? dBCALGeom->GetBCAL_NInnerSectors() : dBCALGeom->GetBCAL_NOuterSectors();
-		 int n_sectors = dBCALGeom->GetBCAL_Nsectors();
+		 int n_sectors = bcal_config->BCAL_NUM_SECTORS;
          for(int fADC_sec=1; fADC_sec<=n_sectors; fADC_sec++){
 
             // Use cellId(...) to convert fADC layer and sector into fADCId

--- a/src/programs/Simulation/mcsmear/MyProcessor.cc
+++ b/src/programs/Simulation/mcsmear/MyProcessor.cc
@@ -167,7 +167,6 @@ jerror_t MyProcessor::brun(JEventLoop *loop, int locRunNumber)
 
         // load the CCDB context
         DApplication* locDApp = dynamic_cast<DApplication*>(japp);
-        //DGeometry *dgeom=locDApp->GetDGeometry(locRunNumber);
         JCalibration* jcalib = locDApp->GetJCalibration(locRunNumber);
     
         string context = jcalib->GetContext();


### PR DESCRIPTION
This change will make the current version of halld_sim compile with both the current halld_recon and the old sim-recon. It takes advantage of redundancy in some hardcoded geometry parameters.

Someone (me) should sit down and think more carefully about the (few) dependencies between this program and halld_recon, and how best to handle this in the future.