### PR TITLE
Dalton omega tslope

### DIFF
--- a/src/libraries/AMPTOOLS_MCGEN/GammaPToXYZP.cc
+++ b/src/libraries/AMPTOOLS_MCGEN/GammaPToXYZP.cc
@@ -18,8 +18,8 @@
 GammaPToXYZP::GammaPToXYZP( float lowMassXYZ, float highMassXYZ, 
         float massX, float massY, float massZ,
         ProductionMechanism::Type type,
-        float beamMaxE = 12.0, float beamPeakE = 9.0, float beamLowE = 7.0, float beamHighE = 12.0) : 
-    m_prodMech( ProductionMechanism::kProton, type, 7.5 ), // last arg is t dependence
+        float beamMaxE, float beamPeakE, float beamLowE, float beamHighE, float slope) :
+    m_prodMech( ProductionMechanism::kProton, type, slope), // last arg is t dependence
     m_target( 0, 0, 0, 0.938 ),
     m_childMass( 0 ) 
 {

--- a/src/libraries/AMPTOOLS_MCGEN/GammaPToXYZP.h
+++ b/src/libraries/AMPTOOLS_MCGEN/GammaPToXYZP.h
@@ -25,7 +25,7 @@ public:
   GammaPToXYZP( float lowMassXYZ, float highMassXYZ, 
                 float massX, float massY, float massZ,
                 ProductionMechanism::Type type, 
-                float beamMaxE, float beamPeakE, float beamLowE, float beamHighE );
+                float beamMaxE = 12.0, float beamPeakE = 9.0, float beamLowE = 7.0, float beamHighE = 12.0, float slope = 7.5);
   
   Kinematics* generate();
 //  AmpVecs* generateMany( int nEvents );

--- a/src/programs/Simulation/gen_3pi/gen_3pi.cc
+++ b/src/programs/Simulation/gen_3pi/gen_3pi.cc
@@ -53,6 +53,7 @@ int main( int argc, char* argv[] ){
   double beamPeakE  = 9.0;
   double beamLowE   = 7.5;
   double beamHighE  = 9.5;
+  double t_slope    = 7.5;
 
   int runNum = 9001;
   int seed = 0;
@@ -148,7 +149,7 @@ int main( int argc, char* argv[] ){
     ( genFlat ? ProductionMechanism::kFlat : ProductionMechanism::kResonant );
    
   // generate over a range of mass -- the daughters are three charged pions
-  GammaPToXYZP resProd( lowMass, highMass, 0.140, 0.140, 0.140, type, beamMaxE, beamPeakE, beamLowE, beamHighE );
+  GammaPToXYZP resProd( lowMass, highMass, 0.140, 0.140, 0.140, type, beamMaxE, beamPeakE, beamLowE, beamHighE, t_slope);
   
   // seed the distribution with a sum of noninterfering Breit-Wigners
   // we can easily compute the PDF for this and divide by that when

--- a/src/programs/Simulation/gen_omega_3pi/gen_omega_3pi.cc
+++ b/src/programs/Simulation/gen_omega_3pi/gen_omega_3pi.cc
@@ -50,6 +50,7 @@ int main( int argc, char* argv[] ){
 	double beamPeakE  = 9.0;
 	double beamLowE   = 7.5;
 	double beamHighE  = 9.5;
+	double t_slope    = 5.0;
 	
 	int runNum = 9001;
 	int seed = 0;
@@ -148,7 +149,7 @@ int main( int argc, char* argv[] ){
 		( genFlat ? ProductionMechanism::kFlat : ProductionMechanism::kResonant );
 	
 	// generate over a range of mass 
-	GammaPToXYZP resProd( lowMass, highMass, 0.140, 0.140, 0.135, type , beamMaxE, beamPeakE, beamLowE, beamHighE );
+	GammaPToXYZP resProd( lowMass, highMass, 0.140, 0.140, 0.135, type , beamMaxE, beamPeakE, beamLowE, beamHighE, t_slope);
 	
 	// seed the distribution with a sum of noninterfering Breit-Wigners
 	// we can easily compute the PDF for this and divide by that when

--- a/src/programs/Simulation/gen_omega_radiative/gen_omega_radiative.cc
+++ b/src/programs/Simulation/gen_omega_radiative/gen_omega_radiative.cc
@@ -50,6 +50,7 @@ int main( int argc, char* argv[] ){
 	double beamPeakE  = 9.0;
 	double beamLowE   = 7.5;
 	double beamHighE  = 9.5;
+	double t_slope    = 5.0;
 	
 	int runNum = 10000;
 	int seed = 0;
@@ -148,7 +149,7 @@ int main( int argc, char* argv[] ){
 		( genFlat ? ProductionMechanism::kFlat : ProductionMechanism::kResonant );
 	
 	// generate over a range of mass 
-	GammaPToXYP resProd( lowMass, highMass, 0.135, 0.0, beamMaxE, beamPeakE, beamLowE, beamHighE, type );
+	GammaPToXYP resProd( lowMass, highMass, 0.135, 0.0, beamMaxE, beamPeakE, beamLowE, beamHighE, type, t_slope);
 	
 	// seed the distribution with a sum of noninterfering Breit-Wigners
 	// we can easily compute the PDF for this and divide by that when


### PR DESCRIPTION
Made t slope a parameter in the constructor of GammaPToXYZP.
The previous hard coded value for the slope of 7.5 is now set as the default value.
Moved default values to header file so that files including the header are aware that not all parameters are required.  (Necessary for backward compatibility.)
Modified the simulations which call GammaPToXYZP to make t slope explicit. (Only gen_3pi and gen_omega_3pi do this.)
Set t slope in both generators of omega to 5.0 to better match the slope in data.
