### PR TITLE
remove SiPM_saturation variable

### DIFF
--- a/src/programs/Simulation/mcsmear/mcsmear_config.cc
+++ b/src/programs/Simulation/mcsmear/mcsmear_config.cc
@@ -27,6 +27,13 @@ mcsmear_config_t::mcsmear_config_t()
 	APPLY_EFFICIENCY_CORRECTIONS = true;
 	APPLY_HITS_TRUNCATION = true;
     FCAL_ADD_LIGHTGUIDE_HITS = false;
+
+          BCAL_NO_T_SMEAR = false;             
+          BCAL_NO_DARK_PULSES = false;        
+          BCAL_NO_SAMPLING_FLUCTUATIONS = false;
+          BCAL_NO_SAMPLING_FLOOR_TERM = false; 
+          BCAL_NO_POISSON_STATISTICS = false;  
+	  BCAL_NO_FADC_SATURATION = false;   
 		
 	TRIGGER_LOOKBACK_TIME = -100; // ns
 		


### PR DESCRIPTION
mcsmear parameters for BCAL were previously uninitiated. This sets the variables to their default values (false).