### PR TITLE
Gen binary consistancy

### DIFF
--- a/src/SBMS/sbms.py
+++ b/src/SBMS/sbms.py
@@ -1062,6 +1062,7 @@ def AddAmpTools(env):
 			AMPTOOLS_LIBS = 'AmpTools_GPU'
 			print 'Using GPU enabled AMPTOOLS library'
 
+                env.AppendUnique(CXXFLAGS = ['-DHAVE_AMPTOOLS_MCGEN'])
 		env.AppendUnique(CPPPATH = AMPTOOLS_CPPPATH)
 		env.AppendUnique(LIBPATH = AMPTOOLS_LIBPATH)
 		env.AppendUnique(LIBS    = AMPTOOLS_LIBS)

--- a/src/programs/Simulation/genEtaRegge/SConscript
+++ b/src/programs/Simulation/genEtaRegge/SConscript
@@ -6,10 +6,11 @@ import sbms
 Import('*')
 env = env.Clone()
 
-sbms.AddAmpTools(env)
+
 sbms.AddCobrems(env)
 sbms.AddROOT(env)
 sbms.AddHDDM(env)
+sbms.AddAmpTools(env)
 sbms.executable(env)
 
 

--- a/src/programs/Simulation/genEtaRegge/SConscript
+++ b/src/programs/Simulation/genEtaRegge/SConscript
@@ -6,6 +6,7 @@ import sbms
 Import('*')
 env = env.Clone()
 
+sbms.AddAmpTools(env)
 sbms.AddCobrems(env)
 sbms.AddROOT(env)
 sbms.AddHDDM(env)

--- a/src/programs/Simulation/genEtaRegge/genEtaRegge.cc
+++ b/src/programs/Simulation/genEtaRegge/genEtaRegge.cc
@@ -677,6 +677,4 @@ int main(int narg, char *argv[])
 
 	return 0;
 }
-
 #endif   // HAVE_AMPTOOLS_MCGEN
-

--- a/src/programs/Simulation/gen_ee/code/SConscript
+++ b/src/programs/Simulation/gen_ee/code/SConscript
@@ -9,5 +9,5 @@ env = env.Clone()
 	
 sbms.AddHDDM(env)
 sbms.AddROOT(env)
-sbms.executable(env, 'ee_mc')
+sbms.executable(env, 'gen_ee')
 #sbms.executable(env)

--- a/src/programs/Simulation/gen_ee_hb/HallBTCS/SConscript
+++ b/src/programs/Simulation/gen_ee_hb/HallBTCS/SConscript
@@ -9,5 +9,5 @@ env = env.Clone()
 	
 sbms.AddHDDM(env)
 sbms.AddROOT(env)
-sbms.executable(env, 'ee_mc_hb')
+sbms.executable(env, 'gen_ee_hb')
 #sbms.executable(env)

--- a/src/programs/Simulation/mcsmear/mcsmear.cc
+++ b/src/programs/Simulation/mcsmear/mcsmear.cc
@@ -96,7 +96,7 @@ void ParseCommandLineArguments(int narg, char* argv[], mcsmear_config_t *config)
           case 'h': Usage();                                     break;
           case 'o': OUTFILENAME = strdup(&ptr[2]);               break;
           case 'N': config->ADD_NOISE=true;                      break;
-	 case 's': config->SMEAR_HITS=false;cout<<"I'M NOT SMEARING"<<endl;                    break;
+	  case 's': config->SMEAR_HITS=false;                    break;
           case 'i': config->IGNORE_SEEDS=true;                   break;
           case 'r': config->SetSeeds(&ptr[2]);                   break;
           case 'd': config->DROP_TRUTH_HITS=true;                break;

--- a/src/programs/Simulation/mcsmear/mcsmear.cc
+++ b/src/programs/Simulation/mcsmear/mcsmear.cc
@@ -96,7 +96,7 @@ void ParseCommandLineArguments(int narg, char* argv[], mcsmear_config_t *config)
           case 'h': Usage();                                     break;
           case 'o': OUTFILENAME = strdup(&ptr[2]);               break;
           case 'N': config->ADD_NOISE=true;                      break;
-          case 's': config->SMEAR_HITS=false;                    break;
+	 case 's': config->SMEAR_HITS=false;cout<<"I'M NOT SMEARING"<<endl;                    break;
           case 'i': config->IGNORE_SEEDS=true;                   break;
           case 'r': config->SetSeeds(&ptr[2]);                   break;
           case 'd': config->DROP_TRUTH_HITS=true;                break;


### PR DESCRIPTION
made the binary names of gen_ee and gen_ee_hb consistent with the file names.  This will cause MCwrapper v2.0 and earlier to break.  v2.0.1 will fix this.

Also changed sbms.py to properly flag the precompiler switch HAVE_AMPTOOLS_MCGEN when addAmpTools(env) is called.  This fixes a bug in which genEtaRegge would not properly compile