### PR TITLE
Config file for eta pi- delta++ with amplitudes

### DIFF
--- a/src/programs/Simulation/gen_amp/gen_EtaPiMinusDelta.cfg
+++ b/src/programs/Simulation/gen_amp/gen_EtaPiMinusDelta.cfg
@@ -1,0 +1,65 @@
+# -a 8.0 -b 9.0
+#####################################
+####	THIS IS A CONFIG FILE	 ####
+#####################################
+##
+##  Blank lines or lines beginning with a "#" are ignored.
+##
+##  Double colons (::) are treated like a space.
+##     This is sometimes useful for grouping (for example,
+##     grouping strings like "reaction::sum::amplitudeName")
+##
+##  All non-comment lines must begin with one of the following keywords.
+##
+##  (note:  <word> means necessary 
+##	    (word) means optional)
+##
+##  include	  <file>
+##  define	  <word> (defn1) (defn2) (defn3) ...
+##  fit 	  <fitname>
+##  keyword	  <keyword> <min arguments> <max arguments>
+##  reaction	  <reaction> <particle1> <particle2> (particle3) ...
+##  data	  <reaction> <class> (arg1) (arg2) (arg3) ...
+##  genmc	  <reaction> <class> (arg1) (arg2) (arg3) ...
+##  accmc	  <reaction> <class> (arg1) (arg2) (arg3) ...
+##  normintfile   <reaction> <file>
+##  sum 	  <reaction> <sum> (sum2) (sum3) ...
+##  amplitude	  <reaction> <sum> <amp> <class> (arg1) (arg2) ([par]) ... 
+##  initialize    <reaction> <sum> <amp> <"events"/"polar"/"cartesian">
+##		    <value1> <value2> ("fixed"/"real")
+##  scale	  <reaction> <sum> <amp> <value or [parameter]>
+##  constrain	  <reaction1> <sum1> <amp1> <reaction2> <sum2> <amp2> ...
+##  permute	  <reaction> <sum> <amp> <index1> <index2> ...
+##  parameter	  <par> <value> ("fixed"/"bounded"/"gaussian") 
+##		    (lower/central) (upper/error)
+##    DEPRECATED:
+##  datafile	  <reaction> <file> (file2) (file3) ...
+##  genmcfile	  <reaction> <file> (file2) (file3) ...
+##  accmcfile	  <reaction> <file> (file2) (file3) ...
+##
+#####################################
+
+define a0 0.980 0.100
+define a2 1.320 0.110
+define deltapp 1.232 0.100
+
+# Uniform angles: flat=1; YLMs: flat=0;
+define flat 0
+
+fit EtaPi_fit
+
+reaction EtaPi Beam Proton Eta Pi- Pi+
+
+sum EtaPi Negative
+
+amplitude EtaPi::Negative::amp_S0 TwoPSAngles 0 0 -1
+amplitude EtaPi::Negative::amp_S0 BreitWigner deltapp 0 1 4
+amplitude EtaPi::Negative::amp_S0 BreitWigner a0 2 2 3
+
+amplitude EtaPi::Negative::amp_D0 TwoPSAngles 2 0 -1
+amplitude EtaPi::Negative::amp_D0 BreitWigner deltapp 0 1 4
+amplitude EtaPi::Negative::amp_D0 BreitWigner a2 2 2 3
+
+initialize EtaPi::Negative::amp_S0 cartesian 1.0 0.0
+initialize EtaPi::Negative::amp_D0 cartesian 1.0 0.0
+#initialize EtaPi::Negative::amp_P1 cartesian 0.0 0.0


### PR DESCRIPTION
Note: the gen_amp_diagnostic.root histograms will look wrong for this config file. Some minor modification to gen_amp histograms needs to be made to make them look OK. However, if you reconstruct the four vectors from the eta pi- and proton pi+ you should get the correct results.