### PR TITLE
Gen amp baryons

### DIFF
--- a/src/libraries/AMPTOOLS_AMPS/Lambda1520Angles.cc
+++ b/src/libraries/AMPTOOLS_AMPS/Lambda1520Angles.cc
@@ -1,0 +1,102 @@
+
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <cstdlib>
+
+#include "TLorentzVector.h"
+#include "TLorentzRotation.h"
+
+#include "IUAmpTools/Kinematics.h"
+#include "AMPTOOLS_AMPS/Lambda1520Angles.h"
+#include "AMPTOOLS_AMPS/clebschGordan.h"
+#include "AMPTOOLS_AMPS/wignerD.h"
+
+Lambda1520Angles::Lambda1520Angles( const vector< string >& args ) :
+UserAmplitude< Lambda1520Angles >( args )
+{
+	assert( args.size() == 11 );
+	
+	phipol  = atof(args[0].c_str() )*3.14159/180.; // azimuthal angle of the photon polarization vector in the lab.
+	polFrac = AmpParameter( args[1] ); // fraction of polarization (0-1)
+	
+	rho011  = AmpParameter( args[2] );
+	rho031  = AmpParameter( args[3] );
+	rho03m1 = AmpParameter( args[4] );
+	
+	rho111  = AmpParameter( args[5] );
+	rho133  = AmpParameter( args[6] );
+	rho131  = AmpParameter( args[7] );
+	rho13m1 = AmpParameter( args[8] );
+	
+	rho231  = AmpParameter( args[9] );
+	rho23m1 = AmpParameter( args[10] );
+	
+	// need to register any free parameters so the framework knows about them
+	registerParameter( rho011 );
+	registerParameter( rho031 );
+	registerParameter( rho03m1 );
+	
+	registerParameter( rho111 );
+	registerParameter( rho133 );
+	registerParameter( rho131 );
+	registerParameter( rho13m1 );
+	
+	registerParameter( rho231 );
+	registerParameter( rho23m1 );
+}
+
+
+complex< GDouble >
+Lambda1520Angles::calcAmplitude( GDouble** pKin ) const {
+	
+	TLorentzVector target ( 0, 0, 0, 0.9382720813);
+	TLorentzVector beam   ( pKin[0][1], pKin[0][2], pKin[0][3], pKin[0][0] ); 
+	TLorentzVector recoil ( pKin[1][1], pKin[1][2], pKin[1][3], pKin[1][0] ); 
+	TLorentzVector p1     ( pKin[2][1], pKin[2][2], pKin[2][3], pKin[2][0] ); 
+	TLorentzVector p2     ( pKin[3][1], pKin[3][2], pKin[3][3], pKin[3][0] ); 
+	
+	TLorentzVector resonance = p1 + p2;
+	TLorentzRotation resonanceBoost( -resonance.BoostVector() );
+	
+	TLorentzVector target_res = resonanceBoost * target;
+	TLorentzVector beam_res = resonanceBoost * beam;
+	TLorentzVector recoil_res = resonanceBoost * recoil;
+	TLorentzVector p1_res = resonanceBoost * p1;
+	
+	// normal to the production plane
+	TVector3 y = (beam_res.Vect().Unit().Cross(recoil_res.Vect().Unit())).Unit();
+	// choose Gottfried-Jackson frame: z-axis along -target direction in baryon rest frame
+	TVector3 z = -1. * target_res.Vect().Unit();
+	TVector3 x = y.Cross(z).Unit();
+	
+	TVector3 angles( (p1_res.Vect()).Dot(x),
+					(p1_res.Vect()).Dot(y),
+					(p1_res.Vect()).Dot(z) );
+	
+	GDouble sinSqTheta = sin(angles.Theta())*sin(angles.Theta());
+	GDouble cosSqTheta = cos(angles.Theta())*cos(angles.Theta());
+	GDouble sin2Theta = sin(2.*angles.Theta());
+	
+	GDouble phi = angles.Phi();
+	
+	TVector3 eps(cos(phipol), sin(phipol), 0.0); // beam polarization vector in lab
+	GDouble Phi = atan2(y.Dot(eps), beam.Vect().Unit().Dot(eps.Cross(y)));
+	Phi = Phi > 0? Phi : Phi + 3.14159;
+	
+	// SDMEs for 3/2- -> 1/2+ + 0- (doi.org/10.1103/PhysRevC.96.025208)
+	GDouble Pgamma = polFrac;
+	
+	GDouble W = 3.*(0.5 - rho011)*sinSqTheta + rho011*(1.+3.*cosSqTheta) - 2.*TMath::Sqrt(3.)*rho031*cos(phi)*sin2Theta - 2.*TMath::Sqrt(3.)*rho03m1*cos(2.*phi)*sinSqTheta;
+	
+	W -= Pgamma*cos(2.*Phi) * (3.*rho133*sinSqTheta + rho111*(1.+3.*cosSqTheta) - 2.*TMath::Sqrt(3.)*rho131*cos(phi)*sin2Theta - 2.*TMath::Sqrt(3.)*rho13m1*cos(2.*phi)*sinSqTheta);
+	
+	W -= Pgamma*sin(2.*Phi) * (2.*TMath::Sqrt(3.)*rho231*sin(phi)*sin2Theta + 2.*TMath::Sqrt(3.)*rho23m1*sin(2.*phi)*sinSqTheta);
+	
+	W *= 1./(4.*PI);
+	
+	return W;
+// 	return complex< GDouble > ( sqrt(fabs(W)) );
+}
+

--- a/src/libraries/AMPTOOLS_AMPS/Lambda1520Angles.h
+++ b/src/libraries/AMPTOOLS_AMPS/Lambda1520Angles.h
@@ -1,0 +1,51 @@
+#if !defined(LAMBDA1520ANGLES)
+#define LAMBDA1520ANGLES
+
+#include "IUAmpTools/Amplitude.h"
+#include "IUAmpTools/UserAmplitude.h"
+#include "IUAmpTools/AmpParameter.h"
+#include "GPUManager/GPUCustomTypes.h"
+
+#include <string>
+#include <complex>
+#include <vector>
+
+
+
+using std::complex;
+using namespace std;
+
+class Kinematics;
+
+class Lambda1520Angles : public UserAmplitude< Lambda1520Angles >
+{
+    
+public:
+	
+	Lambda1520Angles() : UserAmplitude< Lambda1520Angles >() { };
+	Lambda1520Angles( const vector< string >& args );
+	
+	string name() const { return "Lambda1520Angles"; }
+    
+	complex< GDouble > calcAmplitude( GDouble** pKin ) const;
+
+  
+private:
+  
+	GDouble phipol;
+	AmpParameter polFrac;
+	AmpParameter rho011;
+	AmpParameter rho031;
+	AmpParameter rho03m1;
+	
+	AmpParameter rho111;
+	AmpParameter rho133;
+	AmpParameter rho131;
+	AmpParameter rho13m1;
+	
+	AmpParameter rho231;
+	AmpParameter rho23m1;
+
+};
+
+#endif

--- a/src/libraries/AMPTOOLS_MCGEN/GammaPToNPartP.cc
+++ b/src/libraries/AMPTOOLS_MCGEN/GammaPToNPartP.cc
@@ -15,11 +15,22 @@
 
 #include <CobremsGeneration.hh>
 
+
 GammaPToNPartP::GammaPToNPartP( float lowMass, float highMass, 
 				vector<double> &ChildMass,
 				float beamMaxE, float beamPeakE, float beamLowE, float beamHighE,
 				ProductionMechanism::Type type, float slope, double lowT, double highT, int seed ) : 
-  m_prodMech( ProductionMechanism::kProton, type, slope, seed ),
+	GammaPToNPartP( lowMass, highMass, 
+			ChildMass,
+			beamMaxE, beamPeakE, beamLowE, beamHighE,
+			ProductionMechanism::kProton, type, slope, lowT, highT, seed )
+{}
+
+GammaPToNPartP::GammaPToNPartP( float lowMass, float highMass, 
+				vector<double> &ChildMass,
+				float beamMaxE, float beamPeakE, float beamLowE, float beamHighE,
+				ProductionMechanism::Recoil recoil, ProductionMechanism::Type type, float slope, double lowT, double highT, int seed ) : 
+  m_prodMech( recoil, type, slope, seed ),
   m_target( 0, 0, 0, ParticleMass(Proton) ),
   m_ChildMass(ChildMass)
 {

--- a/src/libraries/AMPTOOLS_MCGEN/GammaPToNPartP.cc
+++ b/src/libraries/AMPTOOLS_MCGEN/GammaPToNPartP.cc
@@ -15,6 +15,9 @@
 
 #include <CobremsGeneration.hh>
 
+GammaPToNPartP::GammaPToNPartP():
+	m_prodMech(ProductionMechanism::kProton,ProductionMechanism::kFlat,0,0)
+{}
 
 GammaPToNPartP::GammaPToNPartP( float lowMass, float highMass, 
 				vector<double> &ChildMass,

--- a/src/libraries/AMPTOOLS_MCGEN/GammaPToNPartP.h
+++ b/src/libraries/AMPTOOLS_MCGEN/GammaPToNPartP.h
@@ -17,7 +17,12 @@ class Kinematics;
 class GammaPToNPartP {
   
 public:
+    
+  GammaPToNPartP( float lowMass, float highMass, 
+		  vector<double> &ChildMass,
+		  float beamMaxE, float beamPeakE, float beamLowE, float beamHigh, ProductionMechanism::Recoil recoil, ProductionMechanism::Type type, float slope = 6.0, double lowT = 0.0, double highT = 12.0, int seed = 0 );
   
+  //overload constructor for backwards compatibility
   GammaPToNPartP( float lowMass, float highMass, 
 		  vector<double> &ChildMass,
 		  float beamMaxE, float beamPeakE, float beamLowE, float beamHigh, ProductionMechanism::Type type, float slope = 6.0, double lowT = 0.0, double highT = 12.0, int seed = 0 );

--- a/src/libraries/AMPTOOLS_MCGEN/GammaPToNPartP.h
+++ b/src/libraries/AMPTOOLS_MCGEN/GammaPToNPartP.h
@@ -17,7 +17,8 @@ class Kinematics;
 class GammaPToNPartP {
   
 public:
-    
+  GammaPToNPartP();
+	
   GammaPToNPartP( float lowMass, float highMass, 
 		  vector<double> &ChildMass,
 		  float beamMaxE, float beamPeakE, float beamLowE, float beamHigh, ProductionMechanism::Recoil recoil, ProductionMechanism::Type type, float slope = 6.0, double lowT = 0.0, double highT = 12.0, int seed = 0 );

--- a/src/libraries/AMPTOOLS_MCGEN/ProductionMechanism.cc
+++ b/src/libraries/AMPTOOLS_MCGEN/ProductionMechanism.cc
@@ -26,7 +26,10 @@ m_lastWeight( 1. )
   kMneutron=ParticleMass(Neutron);
   // kMZ = 108.;      //  mass of Sn116 
   kMZ = 208.*0.931494;      //  use mass of Pb as it is in the particle table
+  kMPion = ParticleMass(PiPlus);
   kMKaon = ParticleMass(KPlus);
+  
+  isBaryonResonance = false;
 
   // initialize pseudo-random generator
   gRandom->SetSeed(seed);
@@ -36,7 +39,8 @@ m_lastWeight( 1. )
   case kProton:  m_recMass = kMproton; break; //old value: 0.9382
   case kNeutron: m_recMass = kMneutron; break; //old value: 0.9395
   case kZ: m_recMass = kMZ; break; //default to Sn116/Pb
-  case kKaon: m_recMass = kMKaon; break;
+  case kPion: m_recMass = kMPion; isBaryonResonance = true; break;
+  case kKaon: m_recMass = kMKaon; isBaryonResonance = true; break;
   default:       m_recMass = kMproton; break; //old value: 0.9382
   }
 }
@@ -96,7 +100,7 @@ ProductionMechanism::produceResonance( const TLorentzVector& beam ){
   while( random( 0., exptMax ) > exp(-m_slope*t) );   // remove factor of t for rho production (no spin flip). Set this line for exp(Bt)
   
   TVector3 resonanceMomCM;
-  if(m_recMass == kMKaon){
+  if(isBaryonResonance){
 	resonanceMomCM.SetMagThetaPhi( resMomCM,
 					kPi-acos( 1. - 2.*t/tMax ), // opposite of what it would be for meson resonances
 					random( -kPi, kPi ) );

--- a/src/libraries/AMPTOOLS_MCGEN/ProductionMechanism.cc
+++ b/src/libraries/AMPTOOLS_MCGEN/ProductionMechanism.cc
@@ -26,6 +26,7 @@ m_lastWeight( 1. )
   kMneutron=ParticleMass(Neutron);
   // kMZ = 108.;      //  mass of Sn116 
   kMZ = 208.*0.931494;      //  use mass of Pb as it is in the particle table
+  kMKaon = ParticleMass(KPlus);
 
   // initialize pseudo-random generator
   gRandom->SetSeed(seed);
@@ -35,6 +36,7 @@ m_lastWeight( 1. )
   case kProton:  m_recMass = kMproton; break; //old value: 0.9382
   case kNeutron: m_recMass = kMneutron; break; //old value: 0.9395
   case kZ: m_recMass = kMZ; break; //default to Sn116/Pb
+  case kKaon: m_recMass = kMKaon; break;
   default:       m_recMass = kMproton; break; //old value: 0.9382
   }
 }
@@ -77,7 +79,7 @@ ProductionMechanism::produceResonance( const TLorentzVector& beam ){
   double t, tMin, tMax, resMass, resMomCM;
   
   do {
-    do // the resonance mass cannot be larger than CM energy - proton mass
+    do // the resonance mass cannot be larger than CM energy - recoil mass
       resMass = generateMass();
     while ( cmEnergy < resMass + m_recMass );
     resMomCM  = cmMomentum( cmEnergy, resMass, m_recMass );
@@ -94,9 +96,16 @@ ProductionMechanism::produceResonance( const TLorentzVector& beam ){
   while( random( 0., exptMax ) > exp(-m_slope*t) );   // remove factor of t for rho production (no spin flip). Set this line for exp(Bt)
   
   TVector3 resonanceMomCM;
-  resonanceMomCM.SetMagThetaPhi( resMomCM,
-				 acos( 1. - 2.*t/tMax ),
-				 random( -kPi, kPi ) );
+  if(m_recMass == kMKaon){
+	resonanceMomCM.SetMagThetaPhi( resMomCM,
+					kPi-acos( 1. - 2.*t/tMax ), // opposite of what it would be for meson resonances
+					random( -kPi, kPi ) );
+  }
+  else{
+	resonanceMomCM.SetMagThetaPhi( resMomCM,
+					acos( 1. - 2.*t/tMax ),
+					random( -kPi, kPi ) );
+  }
   
   TLorentzVector resonanceCM( resonanceMomCM, 
 			      sqrt( resonanceMomCM.Mag2() +

--- a/src/libraries/AMPTOOLS_MCGEN/ProductionMechanism.h
+++ b/src/libraries/AMPTOOLS_MCGEN/ProductionMechanism.h
@@ -17,7 +17,7 @@ class ProductionMechanism
 public:
 	
 	enum Type { kResonant, kFlat };
-	enum Recoil { kProton, kNeutron, kZ, kKaon };
+	enum Recoil { kProton, kNeutron, kZ, kPion, kKaon };
 	
 	ProductionMechanism( Recoil recoil, Type type, double slope = 5.0, int seed = 0 );
 	
@@ -37,7 +37,7 @@ public:
 private:
   
   static const double kPi;
-  double kMproton,kMneutron,kMZ,kMKaon;
+  double kMproton,kMneutron,kMZ, kMPion, kMKaon;
 
   double generateMass();
   
@@ -53,6 +53,8 @@ private:
 	double m_highT;
   
 	double m_recMass;
+	
+	bool isBaryonResonance;
   
   double m_lastWeight;
   

--- a/src/libraries/AMPTOOLS_MCGEN/ProductionMechanism.h
+++ b/src/libraries/AMPTOOLS_MCGEN/ProductionMechanism.h
@@ -17,7 +17,7 @@ class ProductionMechanism
 public:
 	
 	enum Type { kResonant, kFlat };
-	enum Recoil { kProton, kNeutron, kZ };
+	enum Recoil { kProton, kNeutron, kZ, kKaon };
 	
 	ProductionMechanism( Recoil recoil, Type type, double slope = 5.0, int seed = 0 );
 	
@@ -37,7 +37,7 @@ public:
 private:
   
   static const double kPi;
-  double kMproton,kMneutron,kMZ;
+  double kMproton,kMneutron,kMZ,kMKaon;
 
   double generateMass();
   

--- a/src/programs/Simulation/gen_amp/gen_Lambda1520K.cfg
+++ b/src/programs/Simulation/gen_amp/gen_Lambda1520K.cfg
@@ -1,0 +1,60 @@
+# -t 1.5 -a 8.2 -b 8.8
+#####################################
+####	THIS IS A CONFIG FILE	 ####
+#####################################
+##
+##  Blank lines or lines beginning with a "#" are ignored.
+##
+##  Double colons (::) are treated like a space.
+##     This is sometimes useful for grouping (for example,
+##     grouping strings like "reaction::sum::amplitudeName")
+##
+##  All non-comment lines must begin with one of the following keywords.
+##
+##  (note:  <word> means necessary 
+##	    (word) means optional)
+##
+##  include	  <file>
+##  define	  <word> (defn1) (defn2) (defn3) ...
+##  fit 	  <fitname>
+##  keyword	  <keyword> <min arguments> <max arguments>
+##  reaction	  <reaction> <particle1> <particle2> (particle3) ...
+##  data	  <reaction> <class> (arg1) (arg2) (arg3) ...
+##  genmc	  <reaction> <class> (arg1) (arg2) (arg3) ...
+##  accmc	  <reaction> <class> (arg1) (arg2) (arg3) ...
+##  normintfile   <reaction> <file>
+##  sum 	  <reaction> <sum> (sum2) (sum3) ...
+##  amplitude	  <reaction> <sum> <amp> <class> (arg1) (arg2) ([par]) ... 
+##  initialize    <reaction> <sum> <amp> <"events"/"polar"/"cartesian">
+##		    <value1> <value2> ("fixed"/"real")
+##  scale	  <reaction> <sum> <amp> <value or [parameter]>
+##  constrain	  <reaction1> <sum1> <amp1> <reaction2> <sum2> <amp2> ...
+##  permute	  <reaction> <sum> <amp> <index1> <index2> ...
+##  parameter	  <par> <value> ("fixed"/"bounded"/"gaussian") 
+##		    (lower/central) (upper/error)
+##    DEPRECATED:
+##  datafile	  <reaction> <file> (file2) (file3) ...
+##  genmcfile	  <reaction> <file> (file2) (file3) ...
+##  accmcfile	  <reaction> <file> (file2) (file3) ...
+##
+#####################################
+
+#Useful definition
+define Lambda1520 1.5195 0.0156
+
+#Beam configuration file
+# define beamconfig TEMPBEAMCONFIG
+
+fit LambdaSDME
+
+reaction LambdaK Beam K+ K- Proton
+
+# consider just x polarized amplitudes
+sum LambdaK xpol
+
+# Currently not using any input parameters for TwoPiAngles in the generator
+amplitude LambdaK::xpol::res BreitWigner Lambda1520 2 2 3
+amplitude LambdaK::xpol::res Lambda1520Angles 0 0.37 0.217 -0.063 0.257 0.182 0.179 0.039 0.237 0.024 0.001
+
+initialize LambdaK::xpol::res cartesian 1.0 0.0 
+

--- a/src/programs/Simulation/gen_amp/gen_amp.cc
+++ b/src/programs/Simulation/gen_amp/gen_amp.cc
@@ -227,7 +227,7 @@ int main( int argc, char* argv[] ){
 	else if(isPionRecoil)
 		resProd = GammaPToNPartP( threshold<lowMass ? lowMass : threshold, highMass, childMasses, beamMaxE, beamPeakE, beamLowE, beamHighE, ProductionMechanism::kPion, type, slope, lowT, highT, seed );
 	else
-		resProd = GammaPToNPartP( threshold<lowMass ? lowMass : threshold, highMass, childMasses, beamMaxE, beamPeakE, beamLowE, beamHighE, type, slope, lowT, highT, seed );
+		resProd = GammaPToNPartP( threshold<lowMass ? lowMass : threshold, highMass, childMasses, beamMaxE, beamPeakE, beamLowE, beamHighE, ProductionMechanism::kProton, type, slope, lowT, highT, seed );
 	
 	if (childMasses.size() < 2){
 	  cout << "ConfigFileParser ERROR:  single particle production is not yet implemented" << endl; 
@@ -345,7 +345,7 @@ int main( int argc, char* argv[] ){
 					TLorentzVector p1 = evt->particle ( 2 );
 					TLorentzVector target(0,0,0,recoil[3]);
 					
-					if(isKaonRecoil)
+					if(isKaonRecoil || isPionRecoil)
 						t->Fill(-1*(beam-evt->particle(1)).M2());
 					else
 						t->Fill(-1*(evt->particle(1)-target).M2());

--- a/src/programs/Simulation/gen_amp/gen_amp.cc
+++ b/src/programs/Simulation/gen_amp/gen_amp.cc
@@ -221,7 +221,10 @@ int main( int argc, char* argv[] ){
 	// generate over a range of mass
 	// start with threshold or lowMass, whichever is higher
 	GammaPToNPartP resProd( threshold<lowMass ? lowMass : threshold, highMass, childMasses, beamMaxE, beamPeakE, beamLowE, beamHighE, type, slope, lowT, highT, seed );
-
+	if(isBaryonResonance) // not elegant
+		resProd = GammaPToNPartP( threshold<lowMass ? lowMass : threshold, highMass, childMasses, beamMaxE, beamPeakE, beamLowE, beamHighE, ProductionMechanism::kKaon, type, slope, lowT, highT, seed );
+	
+	
 	if (childMasses.size() < 2){
 	  cout << "ConfigFileParser ERROR:  single particle production is not yet implemented" << endl; 
 	  return 1;

--- a/src/programs/Simulation/gen_amp/gen_amp.cc
+++ b/src/programs/Simulation/gen_amp/gen_amp.cc
@@ -177,7 +177,8 @@ int main( int argc, char* argv[] ){
 	const vector<ConfigFileLine> configFileLines = parser.getConfigFileLines();
 	double resonance[]={1.0, 1.0};
 	bool foundResonance = false;
-	bool isBaryonResonance = false;
+	bool isKaonRecoil = false;
+	bool isPionRecoil = false;
 	for (vector<ConfigFileLine>::const_iterator it=configFileLines.begin(); it!=configFileLines.end(); it++) {
 	  if ((*it).keyword() == "define") {
 	    if ((*it).arguments()[0] == "rho" || (*it).arguments()[0] == "omega" || (*it).arguments()[0] == "phi" || (*it).arguments()[0] == "b1" || (*it).arguments()[0] == "a1" || (*it).arguments()[0] == "Lambda1520"){
@@ -187,7 +188,7 @@ int main( int argc, char* argv[] ){
 	      resonance[1]=atof((*it).arguments()[2].c_str());
 	      cout << "Distribution seeded with resonance " << (*it).arguments()[0] << " : mass = " << resonance[0] << "GeV , width = " << resonance[1] << "GeV" << endl; 
 	      if((*it).arguments()[0] == "Lambda1520")
-		 isBaryonResonance = true;
+		 isKaonRecoil = true;
 	      foundResonance = true;
 	      break;
 	    }
@@ -220,10 +221,13 @@ int main( int argc, char* argv[] ){
 
 	// generate over a range of mass
 	// start with threshold or lowMass, whichever is higher
-	GammaPToNPartP resProd( threshold<lowMass ? lowMass : threshold, highMass, childMasses, beamMaxE, beamPeakE, beamLowE, beamHighE, type, slope, lowT, highT, seed );
-	if(isBaryonResonance) // not elegant
+	GammaPToNPartP resProd;
+	if(isKaonRecoil)
 		resProd = GammaPToNPartP( threshold<lowMass ? lowMass : threshold, highMass, childMasses, beamMaxE, beamPeakE, beamLowE, beamHighE, ProductionMechanism::kKaon, type, slope, lowT, highT, seed );
-	
+	else if(isPionRecoil)
+		resProd = GammaPToNPartP( threshold<lowMass ? lowMass : threshold, highMass, childMasses, beamMaxE, beamPeakE, beamLowE, beamHighE, ProductionMechanism::kPion, type, slope, lowT, highT, seed );
+	else
+		resProd = GammaPToNPartP( threshold<lowMass ? lowMass : threshold, highMass, childMasses, beamMaxE, beamPeakE, beamLowE, beamHighE, type, slope, lowT, highT, seed );
 	
 	if (childMasses.size() < 2){
 	  cout << "ConfigFileParser ERROR:  single particle production is not yet implemented" << endl; 
@@ -341,7 +345,7 @@ int main( int argc, char* argv[] ){
 					TLorentzVector p1 = evt->particle ( 2 );
 					TLorentzVector target(0,0,0,recoil[3]);
 					
-					if(isBaryonResonance)
+					if(isKaonRecoil)
 						t->Fill(-1*(beam-evt->particle(1)).M2());
 					else
 						t->Fill(-1*(evt->particle(1)-target).M2());

--- a/src/programs/Simulation/gen_amp/gen_amp.cc
+++ b/src/programs/Simulation/gen_amp/gen_amp.cc
@@ -22,6 +22,7 @@
 #include "AMPTOOLS_AMPS/BreitWigner.h"
 #include "AMPTOOLS_AMPS/BreitWigner3body.h"
 #include "AMPTOOLS_AMPS/ThreePiAnglesSchilling.h"
+#include "AMPTOOLS_AMPS/Lambda1520Angles.h"
 
 #include "AMPTOOLS_MCGEN/ProductionMechanism.h"
 #include "AMPTOOLS_MCGEN/GammaPToNPartP.h"
@@ -176,14 +177,17 @@ int main( int argc, char* argv[] ){
 	const vector<ConfigFileLine> configFileLines = parser.getConfigFileLines();
 	double resonance[]={1.0, 1.0};
 	bool foundResonance = false;
+	bool isBaryonResonance = false;
 	for (vector<ConfigFileLine>::const_iterator it=configFileLines.begin(); it!=configFileLines.end(); it++) {
 	  if ((*it).keyword() == "define") {
-	    if ((*it).arguments()[0] == "rho" || (*it).arguments()[0] == "omega" || (*it).arguments()[0] == "phi" || (*it).arguments()[0] == "b1" || (*it).arguments()[0] == "a1"){
+	    if ((*it).arguments()[0] == "rho" || (*it).arguments()[0] == "omega" || (*it).arguments()[0] == "phi" || (*it).arguments()[0] == "b1" || (*it).arguments()[0] == "a1" || (*it).arguments()[0] == "Lambda1520"){
 	      if ( (*it).arguments().size() != 3 )
 		continue;
 	      resonance[0]=atof((*it).arguments()[1].c_str());
 	      resonance[1]=atof((*it).arguments()[2].c_str());
 	      cout << "Distribution seeded with resonance " << (*it).arguments()[0] << " : mass = " << resonance[0] << "GeV , width = " << resonance[1] << "GeV" << endl; 
+	      if((*it).arguments()[0] == "Lambda1520")
+		 isBaryonResonance = true;
 	      foundResonance = true;
 	      break;
 	    }
@@ -204,10 +208,11 @@ int main( int argc, char* argv[] ){
 	AmpToolsInterface::registerAmplitude( TwoPiAngles() );
 	AmpToolsInterface::registerAmplitude( TwoPiAngles_amp() );
 	AmpToolsInterface::registerAmplitude( TwoPSHelicity() );
-    AmpToolsInterface::registerAmplitude( TwoPSAngles() );
+	AmpToolsInterface::registerAmplitude( TwoPSAngles() );
 	AmpToolsInterface::registerAmplitude( BreitWigner() );
 	AmpToolsInterface::registerAmplitude( BreitWigner3body() );
 	AmpToolsInterface::registerAmplitude( ThreePiAnglesSchilling() );
+	AmpToolsInterface::registerAmplitude( Lambda1520Angles() );
 	AmpToolsInterface ati( cfgInfo, AmpToolsInterface::kMCGeneration );
 	
 	ProductionMechanism::Type type =
@@ -333,7 +338,10 @@ int main( int argc, char* argv[] ){
 					TLorentzVector p1 = evt->particle ( 2 );
 					TLorentzVector target(0,0,0,recoil[3]);
 					
-					t->Fill(-1*(evt->particle(1)-target).M2());
+					if(isBaryonResonance)
+						t->Fill(-1*(beam-evt->particle(1)).M2());
+					else
+						t->Fill(-1*(evt->particle(1)-target).M2());
 
 					TLorentzRotation resonanceBoost( -resonance.BoostVector() );
 					


### PR DESCRIPTION
Added capabilities to produce baryons in gen_amp. Currently the meson on the upper vertex has to be a pion or kaon (fixed mass). This could serve as a starting point to also include meson resonances together with baryon production.