### PR TITLE
fix indexing problem in calculation of beta that lead to zero signal …

### DIFF
--- a/src/programs/Simulation/HDGeant/hitFCal.c
+++ b/src/programs/Simulation/HDGeant/hitFCal.c
@@ -284,11 +284,11 @@ void hitForwardEMcal (float xin[4], float xout[4],
          dEcorr *= 0.976;
       }
       else {
-         double beta = pin[5] / pin[4];
-         if (beta > 0.6)
+         double beta = pin[4] / pin[3];
+	 if (beta > 0.6)
             dEcorr *= 1.35;
-         else
-            dEcorr = 0;
+	 else
+	   dEcorr = 0;
       }
 
       float tcorr = t + dist/C_EFFECTIVE;


### PR DESCRIPTION
…for minimum-ionizing particles -- only signals from electromagnetic interactions were surviving.