### PR TITLE
Add gfortran to list of libraries for mcsmear.

### DIFF
--- a/src/programs/Simulation/mcsmear/SConscript
+++ b/src/programs/Simulation/mcsmear/SConscript
@@ -9,6 +9,5 @@ env = env.Clone()
 sbms.AddROOT(env)
 sbms.AddRCDB(env)
 sbms.AddDANA(env)
+env.AppendUnique(LIBS = 'gfortran')
 sbms.executable(env)
-
-


### PR DESCRIPTION
	modified:   programs/Simulation/mcsmear/SConscript
mcsmear need to search the fortran libraries to resolve symbols from the new CCAL library.