### PR TITLE
* Add 3 new fields to the end of the BEAM card in control.in [rtj]

### DIFF
--- a/src/programs/Simulation/HDGeant/beamgen.F
+++ b/src/programs/Simulation/HDGeant/beamgen.F
@@ -69,6 +69,9 @@ c  freq > freqMaximum is generated; a few ppm of these is no problem.
       common /genstate/ppol,rndm
       save /genstate/
 
+      real spot_offset
+      common /beamgenProperties/spot_offset(2)
+
       real x, theta2
 
       call GRNDM(rndm,7)
@@ -242,6 +245,8 @@ c set the x rotation angle to 0 by assigning Epeak = 0 in control.in
       vertex(2) = vertex(2) + ubuf(3)
       nubuf = 3
 #endif
+      vertex(1) = vertex(1) + spot_offset(1)
+      vertex(2) = vertex(2) + spot_offset(2)
       call settofg(vertex,t0)
       if (bgtagonly.eq.0 .or. t0.eq.0) then
         call GSVERT(vertex,0,0,ubuf,nubuf,nvert)
@@ -274,4 +279,27 @@ c set the x rotation angle to 0 by assigning Epeak = 0 in control.in
       enddo
       pol = theta2 / (a(1) + a(2) * theta2 + a(3) * theta2**2)
       abrems_polarization = pol * cos(2*phi)
+      end
+
+      subroutine set_spotsize(spotrms)
+      real spotrms
+*
+* Set the size of the virtual spot (electron beam projection to the
+* entrance plane of the primary collimator) to spotrms (m).
+*
+#include "cobrems.inc"
+      spot = spotrms
+      end
+
+      subroutine set_spotpos(x,y)
+      real x,y
+*
+* Set the position of the virtual spot (electron beam projection to the
+* entrance plane of the primary collimator) to (x,y) in meters relative
+* to the center of the collimator hole.
+*
+      real spot_offset
+      common /beamgenProperties/spot_offset(2)
+      spot_offset(1) = x * 100
+      spot_offset(2) = y * 100
       end

--- a/src/programs/Simulation/HDGeant/control.in
+++ b/src/programs/Simulation/HDGeant/control.in
@@ -30,7 +30,7 @@ c event source is the external Monte Carlo generator that produced the file,
 c but the BEAM card may still be present, and it is needed if beam-related
 c backgrounds are being superimposed on top of the primary event signals,
 c as requested with the BGRATE card (see below).  The beam card accepts
-c the following five parameters.  
+c the following parameters.  
 c      Emax   - end-point energy of the electron beam (GeV)
 c      Epeak  - energy of the primary coherent peak edge (GeV)
 c      Emin   - minimum energy of the coherent bremsstrahlung beam (GeV)
@@ -38,6 +38,9 @@ c      collz  - z position of collimator in m
 c      colld  - diameter of collimator in m 
 c      Eemit  - electron beam emittance in m.rad
 c      radthick - dimaond radiator thickneess in m
+c      spotRMS - virtual spot rms size at the collimator (m)
+c      spotX - x offset of virtual spot from collimator axis (m)
+c      spotY - y offset of virtual spot from collimator axis (m)
 c Omitting the final parameter Emin results in the default value being used.
 c Setting Epeak to zero selects an amorphous radiator instead of diamond.
 cBEAM 10. 9.999 0.0012 76.00 0.005 10.e-9 20.e-6

--- a/src/programs/Simulation/HDGeant/uginit.F
+++ b/src/programs/Simulation/HDGeant/uginit.F
@@ -38,6 +38,12 @@
 *   - all cheat tags have been modified to report all three coordinates
 *     (in the global reference system) instead of only two [rtj]
 *
+* Revision 1.12  2019/02/23 09:36:34  jonesrt
+* Add 3 new fields to the end of the BEAM card in control.in:
+*  (8)  spotRMS - virtual spot rms size at the collimator (m)
+*  (9)  spotX - x offset of virtual spot from collimator axis (m)
+*  (10) spotY - y offset of virtual spot from collimator axis (m)
+*
 * Revision 1.11  2005/01/21 09:36:34  davidl
 * Read in BFIELD and NOSECONDARIES cards and store in hdtrackparams common block
 *
@@ -172,9 +178,9 @@
       integer openInput, skipInput, openOutput
       external openInput, skipInput, openOutput
       real beamE0, beamEpeak, beamEmin, radColDist, colDiam
-      real beamEmit, radThick
+      real beamEmit, radThick, spotRMS, spotX, spotY
       common /beamPars/ beamE0,beamEpeak,beamEmin,radColDist,colDiam,
-     +                  beamEmit, radThick
+     +                  beamEmit, radThick, spotRMS, spotX, spotY
       data beamE0/0/
       data beamEpeak/0/
       data beamEmin/0/
@@ -182,6 +188,9 @@
       data colDiam/0.0034/
       data beamEmit/1e-8/
       data radThick/20e-6/
+      data spotRMS/0/
+      data spotX/0/
+      data spotY/0/
 
 c The following parameters are declared in hdtrackparams.inc above.
       data nosecondaries/0/
@@ -272,7 +281,7 @@ C..geant..
       call ffkey('postsmear',postsmear,1,'INTEGER')
       call ffkey('mcsmearopts',mcsmearopts,64,'MIXED')
       call ffkey('deleteunsmeared',deleteunsmeared,1,'INTEGER')
-      call ffkey('beam',beamE0,7,'REAL')
+      call ffkey('beam',beamE0,10,'REAL')
       call ffkey('genbeam',genbeam_mode,20,'MIXED')
       call ffkey('bfieldmap', bfield_map,20,'MIXED')
       call ffkey('bfieldtype', bfield_type,20,'MIXED')
@@ -427,6 +436,10 @@ c        endif
      +           ' cannot continue.'
         stop
       endif
+      if (spotRMS .gt. 0) then
+        call set_spotsize(spotRMS)
+      endif
+      call set_spotpos(spotX,spotY)
 *
 *             Initialize graphics package
 *


### PR DESCRIPTION
   - spotRMS - virtual spot rms size at the collimator (m)
   - spotX - x offset of virtual spot from collimator axis (m)
   - spotY - y offset of virtual spot from collimator axis (m)
  This leaves control.in backward-compatible with old code, except
  the functionality of changing the virtual spot size and offset
  will not be there in old releases of hdgeant.