### PR TITLE
PrimEx simulation

### DIFF
--- a/src/programs/Simulation/mcsmear/CCALSmearer.cc
+++ b/src/programs/Simulation/mcsmear/CCALSmearer.cc
@@ -1,3 +1,4 @@
+
 #include "CCALSmearer.h"
 
 DCCALGeometry *ccalGeom = NULL;
@@ -6,11 +7,60 @@ DCCALGeometry *ccalGeom = NULL;
 // ccal_config_t  (constructor)
 //-----------
 ccal_config_t::ccal_config_t(JEventLoop *loop) {
-  // default values
-  // (This is just a rough estimate 11/30/2010 DL)
-  CCAL_PHOT_STAT_COEF = 0.035/2.0;
-  CCAL_BLOCK_THRESHOLD = 20.0*k_MeV;
-  CCAL_SIGMA = 200.0e-3;
+
+  // Default Parameters
+
+        CCAL_EN_SCALE  =  1.0962;
+ 	
+	// Measured energy resolution
+	CCAL_EN_P0     =  3.08e-2;
+	CCAL_EN_P1     =  1.e-2;
+	CCAL_EN_P2     =  0.7e-2;	
+
+	// Energy deposition in Geant
+	CCAL_EN_GP0     =  1.71216e-2;
+	CCAL_EN_GP1     =  1.55070e-2;
+	CCAL_EN_GP2     =  0.0;		
+	
+	// Time smearing factor
+	CCAL_TSIGMA     =  0.4;
+	
+	
+	// Single block energy threshold (applied after smearing)
+	CCAL_BLOCK_THRESHOLD = 15.0*k_MeV;
+
+
+
+        // Get values from CCDB
+
+        cout << "Get CCAL/mc_energy parameters from CCDB..." << endl;
+
+	map<string, double> ccalparms;
+
+	if(loop->GetCalib("CCAL/mc_energy", ccalparms)) { 
+	  jerr << "Problem loading CCAL/mc_energy from CCDB!" << endl;
+	} else {
+	  CCAL_EN_SCALE   = ccalparms["CCAL_EN_SCALE"]; 
+
+	  CCAL_EN_P0    =  ccalparms["CCAL_EN_P0"]; 
+	  CCAL_EN_P1    =  ccalparms["CCAL_EN_P1"]; 
+	  CCAL_EN_P2    =  ccalparms["CCAL_EN_P2"]; 
+
+	  CCAL_EN_GP0   =  ccalparms["CCAL_EN_GP0"]; 
+	  CCAL_EN_GP1   =  ccalparms["CCAL_EN_GP1"]; 
+	  CCAL_EN_GP2   =  ccalparms["CCAL_EN_GP2"]; 
+        }
+
+	cout<<"get CCAL/mc_time parameters from calibDB"<<endl;
+
+	map<string, double> ccaltime;
+	if(loop->GetCalib("CCAL/mc_time", ccaltime)) {
+	  jerr << "Problem loading CCAL/mc_time from CCDB!" << endl;
+	} else {
+	  CCAL_TSIGMA = ccaltime["CCAL_TSIGMA"];
+	}
+	
+
 }
 
 
@@ -19,12 +69,11 @@ ccal_config_t::ccal_config_t(JEventLoop *loop) {
 // SmearEvemt
 //-----------
 void CCALSmearer::SmearEvent(hddm_s::HDDM *record){
-  /// Smear the CCAL hits using the same procedure as the FCAL above.
-  /// See those comments for details.
   
   //   if (!ccalGeom)
   //   ccalGeom = new DCCALGeometry();
   
+
   hddm_s::CcalBlockList blocks = record->getCcalBlocks();   
   hddm_s::CcalBlockList::iterator iter;
   for (iter = blocks.begin(); iter != blocks.end(); ++iter) {
@@ -39,31 +88,39 @@ void CCALSmearer::SmearEvent(hddm_s::HDDM *record){
       
       if (!ccalGeom->isBlockActive(iter->getRow(), iter->getColumn()))
 		continue;
-      // Smear the energy and timing of the hit
-      //      double sigma = ccal_config->CCAL_PHOT_STAT_COEF/sqrt(titer->getE()) ;
+
       
       // A.S.  new calibration of the CCAL
       double E = titer->getE();
       double t = titer->getT();
-
-	  if(config->SMEAR_HITS) {
-      	double nphav = E * 2.3e3; // per GeV  Corrections
       
-      	if(nphav < 30)
-			E *= gDRandom.SamplePoisson(nphav)/nphav;           //photostatistics
-      	else 
-			E *= 1.0 + gDRandom.SampleGaussian(1./sqrt(nphav)); //photostatistics
+      E *= ccal_config->CCAL_EN_SCALE;
       
-      	E *= 1.167 + gDRandom.SampleGaussian(0.006);          // calibration
-      	t += gDRandom.SampleGaussian(ccal_config->CCAL_SIGMA);
+      if(config->SMEAR_HITS) {
+	
+	// Expected detector resolution
+	double de_e_expect  =   pow(ccal_config->CCAL_EN_P0/sqrt(E),2) + 
+	  pow(ccal_config->CCAL_EN_P1/E,2) + ccal_config->CCAL_EN_P2*ccal_config->CCAL_EN_P2; 
+	
+	// Subtract intrinsic Geant resolution
+	double de_e_geant   =   pow(ccal_config->CCAL_EN_GP0/sqrt(E),2) + pow(ccal_config->CCAL_EN_GP1/E,2);
+	
+	double sig_res      =   sqrt(de_e_expect - de_e_geant);
+	
+	if(sig_res > 0) 
+	  E *= (1. + gDRandom.SampleGaussian(sig_res));
+	
+	t += gDRandom.SampleGaussian(ccal_config->CCAL_TSIGMA);
+	
       }
-        
-      // Apply a single block threshold. If the (smeared) energy is below this,
-      // then set the energy and time to zero. 	 
-      // A.S. 
+      
+      
+      
+      // A.S.  Don't apply energy threshold at the moment
+
       //         if (E > ccal_config->CCAL_BLOCK_THRESHOLD) {
       hddm_s::CcalHitList hits = iter->addCcalHits();
-      hits().setE(E);
+      hits().setE(E*1000.);
       hits().setT(t);
       //         }
     }

--- a/src/programs/Simulation/mcsmear/CCALSmearer.h
+++ b/src/programs/Simulation/mcsmear/CCALSmearer.h
@@ -13,15 +13,24 @@ class ccal_config_t
   public:
 	ccal_config_t(JEventLoop *loop);
 
+	double CCAL_EN_SCALE;
+	
+	double CCAL_EN_P0;
+	double CCAL_EN_P1;
+	double CCAL_EN_P2;	
+	
+	double CCAL_EN_GP0;
+	double CCAL_EN_GP1;
+	double CCAL_EN_GP2;
+
+	
 	// Time smearing factor
-	double CCAL_SIGMA;
-
-	// Photon-statistics factor for smearing hit energy for CompCal
-	double CCAL_PHOT_STAT_COEF;
-
+	double CCAL_TSIGMA;
+	
+	
 	// Single block energy threshold (applied after smearing)
 	double CCAL_BLOCK_THRESHOLD;
-
+	
 };
 
 

--- a/src/programs/Simulation/mcsmear/MyProcessor.cc
+++ b/src/programs/Simulation/mcsmear/MyProcessor.cc
@@ -205,94 +205,231 @@ jerror_t MyProcessor::brun(JEventLoop *loop, int locRunNumber)
 	bool haveRCDBConfigFile = config->ParseRCDBConfigFile(locRunNumber);
 	if(haveRCDBConfigFile) {
 
-		const double fadc250_period_ns(4.);
-		const double fadc125_period_ns(8.);
+	        const double fadc250_period_ns(4.);
+	        const double fadc125_period_ns(8.);
 		
+		// Default parameters
+
+		int cdc_npeak     =  1;
+		double cdc_ie     =  200.;
+		double cdc_pg     =  4;
+
+		int fdc_nhits     =  100;
+		int fdc_npeak     =  1;
+		double fdc_width  =  80.;
+		double fdc_ie     =  16;
+		double fdc_pg     =  4;
+
+		int stc_npeak     =  3;
+		int stc_nhits     =  8;
+		double stc_width  =  80;
+		double stc_nsa    =  20;
+		double stc_nsb    =  5;
+             
+		int bcal_npeak     =  1;
+		int bcal_nhits     =  8;
+		double bcal_width  =  100;
+		double bcal_nsa    =  26;
+		double bcal_nsb    =  1;
+
+		int tof_npeak     =  3;
+		int tof_nhits     =  64;
+		double tof_width  =  80;
+		double tof_nsa    =  10;
+		double tof_nsb    =  1;
+
+		int fcal_npeak     =  3;
+		double fcal_nsa    =  15;
+		double fcal_nsb    =  1;
+
+		int ps_npeak   =  3;
+		double ps_nsa  =  10;
+		double ps_nsb  =  3;
+
+		int psc_npeak     =  3;
+		int psc_nhits     =  8;
+		double psc_nsa    =  6;
+		double psc_nsb    =  3;
+		double psc_width  =  100;
+
+		int tagm_npeak     =  3;
+		int tagm_nhits     =  8;
+
+		double tagm_width  =  60;
+		double tagm_nsa    =  6;
+		double tagm_nsb    =  3;
+
+		int tpol_npeak  =  1;
+
+
 		// hits merging / truncation parameters for the CDC
-		hddm_s_merger::set_cdc_max_hits(config->readout["CDC"].at("NPEAK"));
-		double cdc_ie = config->readout["CDC"].at("IE");
-		double cdc_pg = config->readout["CDC"].at("PG");
+		if(config->readout["CDC"].size() > 0){
+		  cdc_npeak   =  config->readout["CDC"].at("NPEAK");
+		  cdc_ie      =  config->readout["CDC"].at("IE");
+		  cdc_pg      =  config->readout["CDC"].at("PG");
+		}
+
 		double cdc_gate = (cdc_ie + cdc_pg) * fadc125_period_ns;
+
+		hddm_s_merger::set_cdc_max_hits(cdc_npeak);
 		hddm_s_merger::set_cdc_integration_window_ns(cdc_gate);
 		
+
+
 		// hits merging / truncation parameters for the FDC
-		hddm_s_merger::set_fdc_wires_max_hits(config->readout["FDC"].at("NHITS"));
-		double fdc_width = config->readout["FDC"].at("WIDTH");
-		hddm_s_merger::set_fdc_wires_min_delta_t_ns(fdc_width + 5.);
-		hddm_s_merger::set_fdc_strips_max_hits(config->readout["FDC"].at("NPEAK"));
-		double fdc_ie = config->readout["FDC"].at("IE");
-		double fdc_pg = config->readout["FDC"].at("PG");
+		if(config->readout["FDC"].size() > 0){
+		  fdc_nhits  =  config->readout["FDC"].at("NHITS");
+		  fdc_npeak  =  config->readout["FDC"].at("NPEAK");
+		  fdc_width  =  config->readout["FDC"].at("WIDTH");
+		  fdc_ie     =  config->readout["FDC"].at("IE");
+		  fdc_pg     =  config->readout["FDC"].at("PG");
+		}
+
 		double fdc_gate = (fdc_ie + fdc_pg) * fadc125_period_ns;
+
+		hddm_s_merger::set_fdc_wires_max_hits(fdc_nhits);
+		hddm_s_merger::set_fdc_wires_min_delta_t_ns(fdc_width + 5.);
+		hddm_s_merger::set_fdc_strips_max_hits(fdc_npeak);
 		hddm_s_merger::set_fdc_strips_integration_window_ns(fdc_gate);
-		
+
+
+
 		// hits merging / truncation parameters for the STC
-		hddm_s_merger::set_stc_adc_max_hits(config->readout["ST"].at("NPEAK"));
-		hddm_s_merger::set_stc_tdc_max_hits(config->readout["ST"].at("NHITS"));
-		double stc_width = config->readout["ST"].at("WIDTH");
-		hddm_s_merger::set_stc_min_delta_t_ns(stc_width + 5.);
-		double stc_nsa = config->readout["ST"].at("NSA");
-		double stc_nsb = config->readout["ST"].at("NSB");
+		if(config->readout["ST"].size() > 0){
+		  stc_npeak = config->readout["ST"].at("NPEAK");
+		  stc_nhits = config->readout["ST"].at("NHITS");
+		  stc_width = config->readout["ST"].at("WIDTH");
+		  stc_nsa = config->readout["ST"].at("NSA");
+		  stc_nsb = config->readout["ST"].at("NSB");
+		}
+		
 		double stc_gate = (stc_nsa + stc_nsb) * fadc250_period_ns;
+
+		hddm_s_merger::set_stc_adc_max_hits(stc_npeak);
+		hddm_s_merger::set_stc_tdc_max_hits(stc_nhits);
+		hddm_s_merger::set_stc_min_delta_t_ns(stc_width + 5.);
 		hddm_s_merger::set_stc_integration_window_ns(stc_gate);
 		
+
 		// hits merging / truncation parameters for the BCAL
-		hddm_s_merger::set_bcal_adc_max_hits(config->readout["BCAL"].at("NPEAK"));
-		hddm_s_merger::set_bcal_tdc_max_hits(config->readout["BCAL"].at("NHITS"));
-		double bcal_width = config->readout["BCAL"].at("WIDTH");
-		hddm_s_merger::set_bcal_min_delta_t_ns(bcal_width + 5.);
-		double bcal_nsa = config->readout["BCAL"].at("NSA");
-		double bcal_nsb = config->readout["BCAL"].at("NSB");
+		if(config->readout["BCAL"].size() > 0){
+		  bcal_npeak  =  config->readout["BCAL"].at("NPEAK");
+		  bcal_nhits  =  config->readout["BCAL"].at("NHITS");
+		  bcal_width = config->readout["BCAL"].at("WIDTH");
+		  bcal_nsa = config->readout["BCAL"].at("NSA");
+		  bcal_nsb = config->readout["BCAL"].at("NSB");
+		}
+
 		double bcal_gate = (bcal_nsa + bcal_nsb) * fadc250_period_ns;
+
+		hddm_s_merger::set_bcal_adc_max_hits(bcal_npeak);
+		hddm_s_merger::set_bcal_tdc_max_hits(bcal_nhits);
+		hddm_s_merger::set_bcal_min_delta_t_ns(bcal_width + 5.);
 		hddm_s_merger::set_bcal_integration_window_ns(bcal_gate);
+
+	       
 		
 		// hits merging / truncation parameters for the TOF
-		hddm_s_merger::set_ftof_adc_max_hits(config->readout["TOF"].at("NPEAK"));
-		hddm_s_merger::set_ftof_tdc_max_hits(config->readout["TOF"].at("NHITS"));
-		double ftof_width = config->readout["TOF"].at("WIDTH");
-		hddm_s_merger::set_ftof_min_delta_t_ns(ftof_width + 5.);
-		double tof_nsa = config->readout["TOF"].at("NSA");
-		double tof_nsb = config->readout["TOF"].at("NSB");
+		if(config->readout["TOF"].size() > 0){
+		  tof_npeak = config->readout["TOF"].at("NPEAK");
+		  tof_nhits = config->readout["TOF"].at("NHITS");
+		  tof_width = config->readout["TOF"].at("WIDTH");
+		  tof_nsa = config->readout["TOF"].at("NSA");
+		  tof_nsb = config->readout["TOF"].at("NSB");		  
+		}
+
 		double tof_gate = (tof_nsa + tof_nsb) * fadc250_period_ns;
+
+		hddm_s_merger::set_ftof_adc_max_hits(tof_npeak);
+		hddm_s_merger::set_ftof_tdc_max_hits(tof_nhits);
+		hddm_s_merger::set_ftof_min_delta_t_ns(tof_width + 5.);
 		hddm_s_merger::set_ftof_integration_window_ns(tof_gate);
 		
+
 		// hits merging / truncation parameters for the FCAL
-		hddm_s_merger::set_fcal_max_hits(config->readout["FCAL"].at("NPEAK"));
-		double fcal_nsa = config->readout["FCAL"].at("NSA");
-		double fcal_nsb = config->readout["FCAL"].at("NSB");
+		if(config->readout["FCAL"].size() > 0){
+		  fcal_npeak = config->readout["FCAL"].at("NPEAK");
+		  fcal_nsb = config->readout["FCAL"].at("NSB");
+		  
+		}
+
 		double fcal_gate = (fcal_nsa + fcal_nsb) * fadc250_period_ns;
+
+		hddm_s_merger::set_fcal_max_hits(fcal_npeak);
 		hddm_s_merger::set_fcal_integration_window_ns(fcal_gate);
+
+
 		
 		// hits merging / truncation parameters for the CCAL
-		hddm_s_merger::set_ccal_max_hits(config->readout["FCAL"].at("NPEAK"));
-		hddm_s_merger::set_ccal_integration_window_ns(fcal_gate);
+		int ccal_npeak     =  3;
+		double ccal_nsa    =  15;
+		double ccal_nsb    =  1;
 		
+		if(config->readout["CCAL"].size() > 0){
+		  ccal_npeak = config->readout["CCAL"].at("NPEAK");
+		  ccal_nsb = config->readout["CCAL"].at("NSB");		  
+		}
+
+		double ccal_gate = (ccal_nsa + ccal_nsb) * fadc250_period_ns;
+		
+		hddm_s_merger::set_ccal_max_hits(ccal_npeak);
+		hddm_s_merger::set_ccal_integration_window_ns(ccal_gate);
+
+		
+
+
 		// hits merging / truncation parameters for the PS
-		hddm_s_merger::set_ps_max_hits(config->readout["PS"].at("NPEAK"));
-		double ps_nsa = config->readout["PS"].at("NSA");
-		double ps_nsb = config->readout["PS"].at("NSB");
-		double ps_gate = (ps_nsa + ps_nsb) * fadc250_period_ns;
-		hddm_s_merger::set_ps_integration_window_ns(ps_gate);
-		hddm_s_merger::set_psc_adc_max_hits(config->readout["PSC"].at("NPEAK"));
-		hddm_s_merger::set_psc_tdc_max_hits(config->readout["PSC"].at("NHITS"));
-		double psc_width = config->readout["PSC"].at("WIDTH");
-		hddm_s_merger::set_psc_min_delta_t_ns(psc_width + 5.);
-		double psc_nsa = config->readout["PSC"].at("NSA");
-		double psc_nsb = config->readout["PSC"].at("NSB");
+		if(config->readout["PS"].size() > 0){
+		  ps_npeak = config->readout["PS"].at("NPEAK");
+		  ps_nsa = config->readout["PS"].at("NSA");
+		  ps_nsb = config->readout["PS"].at("NSB");
+		}
+
+		if(config->readout["PSC"].size() > 0){
+		  psc_npeak = config->readout["PSC"].at("NPEAK");
+		  psc_nhits = config->readout["PSC"].at("NHITS");
+		  psc_nsa = config->readout["PSC"].at("NSA");
+		  psc_nsb = config->readout["PSC"].at("NSB");
+		  psc_width = config->readout["PSC"].at("WIDTH");
+		}
+
+		double ps_gate  = (ps_nsa + ps_nsb) * fadc250_period_ns;
 		double psc_gate = (psc_nsa + psc_nsb) * fadc250_period_ns;
+
+		hddm_s_merger::set_ps_max_hits(ps_npeak);
+		hddm_s_merger::set_ps_integration_window_ns(ps_gate);
+
+		hddm_s_merger::set_psc_adc_max_hits(psc_npeak);
+		hddm_s_merger::set_psc_tdc_max_hits(psc_nhits);
+		hddm_s_merger::set_psc_min_delta_t_ns(psc_width + 5.);
 		hddm_s_merger::set_psc_integration_window_ns(psc_gate);
 		
+
 		// hits merging / truncation parameters for the TAGM/TAGH
-		hddm_s_merger::set_tag_adc_max_hits(config->readout["TAGM"].at("NPEAK"));
-		hddm_s_merger::set_tag_tdc_max_hits(config->readout["TAGM"].at("NHITS"));
-		double tag_width = config->readout["TAGM"].at("WIDTH");
-		hddm_s_merger::set_tag_min_delta_t_ns(tag_width + 5.);
-		double tag_nsa = config->readout["TAGM"].at("NSA");
-		double tag_nsb = config->readout["TAGM"].at("NSB");
-		double tag_gate = (tag_nsa + tag_nsb) * fadc250_period_ns;
-		hddm_s_merger::set_tag_integration_window_ns(tag_gate);
+		if(config->readout["TAGM"].size() > 0){
+		  tagm_npeak = config->readout["TAGM"].at("NPEAK");
+		  tagm_nhits = config->readout["TAGM"].at("NHITS");
+		  tagm_width = config->readout["TAGM"].at("WIDTH");
+		  tagm_nsa = config->readout["TAGM"].at("NSA");
+		  tagm_nsb = config->readout["TAGM"].at("NSB");
+		}
+
+		double tagm_gate = (tagm_nsa + tagm_nsb) * fadc250_period_ns;
 		
-		// hits merging / truncation parameters for the TPOL
-		hddm_s_merger::set_tpol_max_hits(config->readout["TPOL"].at("NPEAK"));
+		hddm_s_merger::set_tag_adc_max_hits(tagm_npeak);
+		hddm_s_merger::set_tag_tdc_max_hits(tagm_nhits);
+		hddm_s_merger::set_tag_min_delta_t_ns(tagm_width + 5.);
+		hddm_s_merger::set_tag_integration_window_ns(tagm_gate);
+		
+
+		// hits merging / truncation parameters for the TPOL		
+		if(config->readout["TPOL"].size() > 0){
+		  tpol_npeak = config->readout["TPOL"].at("NPEAK");
+		}
+		
+		hddm_s_merger::set_tpol_max_hits(tpol_npeak);
+
+
 	}
 
 #endif  // HAVE_RCDB

--- a/src/programs/Simulation/mcsmear/mcsmear_config.cc
+++ b/src/programs/Simulation/mcsmear/mcsmear_config.cc
@@ -23,10 +23,10 @@ mcsmear_config_t::mcsmear_config_t()
 	SMEAR_HITS     = true;
 	//SMEAR_BCAL     = true;
 	IGNORE_SEEDS   = false;
-    DUMP_RCDB_CONFIG = false;
+	DUMP_RCDB_CONFIG = false;
 	APPLY_EFFICIENCY_CORRECTIONS = true;
-	APPLY_HITS_TRUNCATION = true;
-    FCAL_ADD_LIGHTGUIDE_HITS = false;
+	APPLY_HITS_TRUNCATION  = true;
+	FCAL_ADD_LIGHTGUIDE_HITS = false;
 
           BCAL_NO_T_SMEAR = false;             
           BCAL_NO_DARK_PULSES = false;        
@@ -140,7 +140,7 @@ bool mcsmear_config_t::ParseRCDBConfigFile(int runNumber)
     }
 
     // Parse CODA config file 
-    vector<string> SectionNames = {"TRIGGER", "GLOBAL", "FCAL", "BCAL", "TOF", "ST", "TAGH",
+    vector<string> SectionNames = {"TRIGGER", "GLOBAL", "FCAL", "CCAL", "BCAL", "TOF", "ST", "TAGH",
                                          "TAGM", "PS", "PSC", "TPOL", "CDC", "FDC"};
     string fileContent = file->GetContent();                               // Get file content
     auto result = rcdb::ConfigParser::Parse(fileContent, SectionNames);    // Parse it!
@@ -181,9 +181,15 @@ bool mcsmear_config_t::ParseRCDBConfigFile(int runNumber)
     double dvalue;
     std::stringstream deco;
     vector<string>::iterator iter;
-    vector<string> fadc250_sys = {"FCAL", "BCAL", "TOF", "ST", "TAGH",
+    vector<string> fadc250_sys = {"FCAL", "CCAL", "BCAL", "TOF", "ST", "TAGH",
                                   "TAGM", "PS", "PSC", "TPOL"};
     for (iter = fadc250_sys.begin(); iter != fadc250_sys.end(); ++iter) {
+
+      // Make sure that the sub-detector exists in the configuration file
+        auto section_length = result.Sections[*iter].Rows;
+        if(section_length.size() == 0) continue;
+
+
         deco.clear();
         deco.str(result.Sections.at(*iter).NameValues["FADC250_NPEAK"]);
         deco >> dvalue;
@@ -204,6 +210,10 @@ bool mcsmear_config_t::ParseRCDBConfigFile(int runNumber)
 
     vector<string> fadc125_sys = {"FDC", "CDC"};
     for (iter = fadc125_sys.begin(); iter != fadc125_sys.end(); ++iter) {
+
+        auto section_length = result.Sections[*iter].Rows;
+        if(section_length.size() == 0) continue;
+
         deco.clear();
         deco.str(result.Sections.at(*iter).NameValues["FADC125_NPEAK"]);
         deco >> dvalue;
@@ -224,6 +234,10 @@ bool mcsmear_config_t::ParseRCDBConfigFile(int runNumber)
 
     vector<string> f1tdc_sys = {"BCAL", "ST", "TAGH", "TAGM", "PSC", "FDC"};
     for (iter = f1tdc_sys.begin(); iter != f1tdc_sys.end(); ++iter) {
+
+        auto section_length = result.Sections[*iter].Rows;
+        if(section_length.size() == 0) continue;
+
         readout[*iter]["NHITS"] = 8.;
         deco.clear();
         deco.str(result.Sections.at(*iter).NameValues["F1TDC_WINDOW"]);
@@ -242,6 +256,10 @@ bool mcsmear_config_t::ParseRCDBConfigFile(int runNumber)
 
     vector<string> tdc1290_sys = {"TOF"};
     for (iter = tdc1290_sys.begin(); iter != tdc1290_sys.end(); ++iter) {
+
+        auto section_length = result.Sections[*iter].Rows;
+        if(section_length.size() == 0) continue;
+
         deco.clear();
         deco.str(result.Sections.at(*iter).NameValues["TDC1290_N_HITS"]);
         deco >> dvalue;


### PR DESCRIPTION
- Add interface with the CCDB (hitCCal), adjust module size and 
attenuation length

- Implement realistic smearing of the energy resolution, and
timing, store calibration parameters in the CCDB

- Prevent smearing from crashing when sub-detector sections
are missing in the DAQ configuration file (parsing config
files from RCDB)