### PR TITLE
mcsmear oct2019 updates

### DIFF
--- a/src/programs/Simulation/mcsmear/MyProcessor.cc
+++ b/src/programs/Simulation/mcsmear/MyProcessor.cc
@@ -202,7 +202,10 @@ jerror_t MyProcessor::brun(JEventLoop *loop, int locRunNumber)
 
 #ifdef HAVE_RCDB
 	// Pull configuration parameters from RCDB
-	bool haveRCDBConfigFile = config->ParseRCDBConfigFile(locRunNumber);
+	bool haveRCDBConfigFile = false;
+	if(!config->SKIP_READING_RCDB) {
+	  haveRCDBConfigFile = config->ParseRCDBConfigFile(locRunNumber);
+	}
 	if(haveRCDBConfigFile) {
 
 	        const double fadc250_period_ns(4.);

--- a/src/programs/Simulation/mcsmear/TOFSmearer.cc
+++ b/src/programs/Simulation/mcsmear/TOFSmearer.cc
@@ -13,6 +13,10 @@ tof_config_t::tof_config_t(JEventLoop *loop)
  	TOF_PHOTONS_PERMEV = 400.;
  	TOF_BAR_THRESHOLD    = 0.0;
 
+	// The interface to DTOFGeometry changed at some point before GlueX-II running to be more flexible.  
+#ifdef DTOFGEOMETRY_VERSION
+#if DTOFGEOMETRY_VERSION > 1
+
 	// load values from geometry
 	vector <const DTOFGeometry*> TOFGeom;
 	loop->Get(TOFGeom);
@@ -61,7 +65,57 @@ tof_config_t::tof_config_t(JEventLoop *loop)
             }	      
         }
     }
-    
+#endif // DTOFGEOMETRY_VERSION > 1
+       // for now there is just DTOFGEOMETRY_VERSION = 2, so this should always work...
+#else 
+	// geometry
+	const int TOF_NUM_PLANES = 2;
+	const int TOF_NUM_BARS = 44;
+
+	// Load data from CCDB
+	cout<<"Get TOF/tof_parms parameters from CCDB..."<<endl;
+	map<string, double> tofparms;
+	if(loop->GetCalib("TOF/tof_parms", tofparms)) {
+	  jerr << "Problem loading TOF/tof_parms from CCDB!" << endl;
+	  return;
+	}
+	
+	TOF_SIGMA =  tofparms["TOF_SIGMA"];
+	TOF_PHOTONS_PERMEV =  tofparms["TOF_PHOTONS_PERMEV"];
+	
+	cout<<"get TOF/paddle_resolutions from calibDB"<<endl;
+	vector <double> TOF_PADDLE_TIME_RESOLUTIONS_TEMP;
+	if(loop->GetCalib("TOF/paddle_resolutions", TOF_PADDLE_TIME_RESOLUTIONS_TEMP)) {
+	  jerr << "Problem loading TOF/paddle_resolutions from CCDB!" << endl;
+	} else {
+	  for (unsigned int i = 0; i < TOF_PADDLE_TIME_RESOLUTIONS_TEMP.size(); i++) {
+	    TOF_PADDLE_TIME_RESOLUTIONS.push_back(TOF_PADDLE_TIME_RESOLUTIONS_TEMP.at(i));
+	  }
+	}
+
+	// load per-channel efficiencies
+	vector<double> raw_table;
+	if(loop->GetCalib("TOF/channel_mc_efficiency", raw_table)) {
+	  jerr << "Problem loading TOF/channel_mc_efficiency from CCDB!" << endl;
+	} else {
+	  int channel = 0;
+
+	  for(int plane=0; plane<TOF_NUM_PLANES; plane++) {
+	    int plane_index=2*TOF_NUM_BARS*plane;
+	    channel_efficiencies.push_back( vector< pair<double,double> >(TOF_NUM_BARS) );
+	    for(int bar=0; bar<TOF_NUM_BARS; bar++) {
+	      channel_efficiencies[plane][bar] 
+                = pair<double,double>(raw_table[plane_index+bar],
+				      raw_table[plane_index+TOF_NUM_BARS+bar]);
+	      channel+=2;
+            }      
+	  }
+	}
+#endif // DTOFGEOMETRY_VERSION
+
+	cout << "****************************************" << endl;
+	cout << "TOF BARS = " << TOF_NUM_BARS << endl;
+	cout << "****************************************" << endl;
 }
 
 

--- a/src/programs/Simulation/mcsmear/mcsmear.cc
+++ b/src/programs/Simulation/mcsmear/mcsmear.cc
@@ -104,6 +104,7 @@ void ParseCommandLineArguments(int narg, char* argv[], mcsmear_config_t *config)
           case 'e': config->APPLY_EFFICIENCY_CORRECTIONS=false;  break;
           case 'm': config->APPLY_HITS_TRUNCATION=false;         break;
           case 'E': config->FCAL_ADD_LIGHTGUIDE_HITS=true;       break;
+	  case 'R': config->SKIP_READING_RCDB=true;              break;
 
           // BCAL parameters
           case 'G': config->BCAL_NO_T_SMEAR = true;              break;
@@ -217,6 +218,7 @@ void Usage(void)
 //   cout << "    -B       Don't process BCAL hits at all (def. process)" << endl;
  //  cout << "    -Vthresh BCAL ADC threshold (def. " << BCAL_ADC_THRESHOLD_MEV << " MeV)" << endl;
  //  cout << "    -Xsigma  BCAL fADC time resolution (def. " << BCAL_FADC_TIME_RESOLUTION << " ns)" << endl;
+   cout << "    -R       Don't load information from RCDB" << endl;
    cout << "    -D       Dump configuration debug information" << endl;
    cout << "    -G       Don't smear BCAL times (def. smear)" << endl;
    cout << "    -H       Don't add BCAL dark hits (def. add)" << endl;

--- a/src/programs/Simulation/mcsmear/mcsmear_config.cc
+++ b/src/programs/Simulation/mcsmear/mcsmear_config.cc
@@ -27,6 +27,7 @@ mcsmear_config_t::mcsmear_config_t()
 	APPLY_EFFICIENCY_CORRECTIONS = true;
 	APPLY_HITS_TRUNCATION  = true;
 	FCAL_ADD_LIGHTGUIDE_HITS = false;
+	SKIP_READING_RCDB = false;
 
           BCAL_NO_T_SMEAR = false;             
           BCAL_NO_DARK_PULSES = false;        
@@ -101,10 +102,10 @@ void  mcsmear_config_t::LoadRCDBConnection()
     if(rcdb_connection != NULL)
         return;
 
-	gPARMS->SetDefaultParameter("RCDB_CONNECTION", RCDB_CONNECTION, "URL used to access RCDB.");
+    gPARMS->SetDefaultParameter("RCDB_CONNECTION", RCDB_CONNECTION, "URL used to access RCDB.");
     
-	// load connection to RCDB
-	rcdb_connection = new rcdb::Connection(RCDB_CONNECTION);
+    // load connection to RCDB
+    rcdb_connection = new rcdb::Connection(RCDB_CONNECTION);
 }
 
 //-----------
@@ -112,7 +113,6 @@ void  mcsmear_config_t::LoadRCDBConnection()
 //-----------
 bool mcsmear_config_t::ParseRCDBConfigFile(int runNumber)
 {
-	// This is just for testing (right now)
 	// To get a lot of the configuration parameters we need, we need to parse the CODA configuration files
 	// which are saved in RCDB in the JSON format
 

--- a/src/programs/Simulation/mcsmear/mcsmear_config.h
+++ b/src/programs/Simulation/mcsmear/mcsmear_config.h
@@ -34,7 +34,8 @@ class mcsmear_config_t
 	bool ADD_NOISE;
 	bool DROP_TRUTH_HITS;
 	bool SMEAR_HITS;
-    bool DUMP_RCDB_CONFIG;
+	bool DUMP_RCDB_CONFIG;
+	bool SKIP_READING_RCDB;
 
 	//bool SMEAR_BCAL;
 	//bool FDC_ELOSS_OFF;


### PR DESCRIPTION
Two main changes to mcsmear:

* Add ability to toggle off the reading of information from the RCDB, for generic MC and other studies which don't correspond to real data
* Switch the way we load the TOF geometry depending on the available API, determined now by a #define.  This will allow us to properly use the latest halld_sim with older halld_recons.