### PR TITLE
Add output to help with debugging mcsmear

### DIFF
--- a/src/programs/Simulation/mcsmear/smear.cc
+++ b/src/programs/Simulation/mcsmear/smear.cc
@@ -72,6 +72,8 @@ Smear::Smear(mcsmear_config_t *in_config, JEventLoop *loop, string detectors_to_
 			}
 		}
 	}
+
+	jout << "Finished initializing detector smearing ..." << endl;
 }
 		
 //-----------


### PR DESCRIPTION
Tell the user when initialization is done, will help separate debugging of problems at initialization time and at processing time.  Motivated by recent errors in the TOF smearing, which were being reported as CCAL problems.