### PR TITLE
Smear the FCAL energy with a term independent of energy

### DIFF
--- a/src/programs/Simulation/mcsmear/FCALSmearer.h
+++ b/src/programs/Simulation/mcsmear/FCALSmearer.h
@@ -24,7 +24,8 @@ class fcal_config_t
         double FCAL_THRESHOLD_SCALING;
         double FCAL_THRESHOLD;
         double FCAL_INTEGRAL_PEAK;
-	
+	double FCAL_ENERGY_WIDTH_FLOOR;
+
     bool FCAL_ADD_LIGHTGUIDE_HITS;
 	
 	vector< vector<double > > block_efficiencies;


### PR DESCRIPTION
Add in the ability to smear the FCAL energy with a term that is independent of energy.  
The parameter is stored in CCDB at FCAL/MC/energy_width_floor