### PR TITLE
Increase gen. config. length name

### DIFF
--- a/src/programs/Simulation/gen_compton_simple/gen_compton_simple.cc
+++ b/src/programs/Simulation/gen_compton_simple/gen_compton_simple.cc
@@ -3,7 +3,7 @@
 * Copyright(C) 20??-2019  GlueX and PrimEX-D Collaborations               * 
 *                                                                         *                                                                                                                               
 * Author: The GlueX and PrimEX-D Collaborations                           *                                                                                                                                
-* Contributors: ????, Igal Jaegle                                         *                                                                                                                               
+* Contributors: Liping Gan, Igal Jaegle                                   *                                                                                                                               
 *                                                                         *                                                                                                                               
 * This software is provided "as is" without any warranty.                 *
 **************************************************************************/

--- a/src/programs/Simulation/gen_primex_eta_he4/HddmOut.h
+++ b/src/programs/Simulation/gen_primex_eta_he4/HddmOut.h
@@ -138,10 +138,10 @@ class HddmOut {
     products->in[2].parentid = 0;
     products->in[2].mech = 0;
     products->in[2].momentum = make_s_Momentum();
-    products->in[2].momentum->px = evt.q2.Px();
-    products->in[2].momentum->py = evt.q2.Py();
-    products->in[2].momentum->pz = evt.q2.Pz();
-    products->in[2].momentum->E = evt.q2.E();
+    products->in[2].momentum->px = evt.q3.Px();
+    products->in[2].momentum->py = evt.q3.Py();
+    products->in[2].momentum->pz = evt.q3.Pz();
+    products->in[2].momentum->E = evt.q3.E();
 
     flush_s_HDDM(hddmEvt, ostream);
 

--- a/src/programs/Simulation/gen_primex_eta_he4/MyReadConfig.cc
+++ b/src/programs/Simulation/gen_primex_eta_he4/MyReadConfig.cc
@@ -19,7 +19,7 @@ MyReadConfig::MyReadConfig() {
   
   strCaLibPath = gSystem->pwd();
   
-  this->ReadConfigFile( "config.dat" );
+  //this->ReadConfigFile( "config.dat" );
 }
 
 //------------------------------------------------------------------------------
@@ -36,7 +36,7 @@ MyReadConfig::~MyReadConfig() {
 //------------------------------------------------------------------------------
 void MyReadConfig::ReadConfigFile( const Char_t *szFin ) {
   // Build File name
-  char szCalibFile[128];
+  char szCalibFile[400];
   sprintf( szCalibFile, 
 	   "%s/%s",
 	   strCaLibPath.Data(),

--- a/src/programs/Simulation/gen_primex_eta_he4/gen_primex_eta_he4.cc
+++ b/src/programs/Simulation/gen_primex_eta_he4/gen_primex_eta_he4.cc
@@ -49,8 +49,8 @@ using std::complex;
 using namespace std;
 
 #define eta_TYPE 17
-#define gamma_TYPE 22
-#define Helium_TYPE 1000020040
+#define gamma_TYPE 1
+#define Helium_TYPE 47
 
 int main( int argc, char* argv[] ){
   


### PR DESCRIPTION
1/ gen_compton_simple: 
Add Liping Gan as original code author
2/ gen_primex_eta_he4:
Increase size chart corresponding to the generator configuration file to allow mcwrapper STANDARD_NAME ie lengthy name.