### PR TITLE
specify accurate pi0 mass for input

### DIFF
--- a/src/programs/Simulation/gen_2pi_primakoff/gen_2pi_primakoff.cc
+++ b/src/programs/Simulation/gen_2pi_primakoff/gen_2pi_primakoff.cc
@@ -178,7 +178,7 @@ int main( int argc, char* argv[] ){
 	
 	// generate over a range of mass -- the daughters are two charged pions
 	float Bslope= 376;   // exponential slope, make it smaller than any slope in the generator.
-	double PiMass = 0.13957;
+	double PiMass = ParticleMass(PiPlus);
 	GammaZToXYZ resProd( lowMass, highMass, PiMass, PiMass, type, beamConfigFile , Bslope);
 	
 	// seed the distribution with a sum of noninterfering s-wave amplitudes

--- a/src/programs/Simulation/gen_2pi_primakoff/gen_2pi_primakoff.cc
+++ b/src/programs/Simulation/gen_2pi_primakoff/gen_2pi_primakoff.cc
@@ -178,7 +178,8 @@ int main( int argc, char* argv[] ){
 	
 	// generate over a range of mass -- the daughters are two charged pions
 	float Bslope= 376;   // exponential slope, make it smaller than any slope in the generator.
-	GammaZToXYZ resProd( lowMass, highMass, 0.140, 0.140, type, beamConfigFile , Bslope);
+	double PiMass = 0.13957;
+	GammaZToXYZ resProd( lowMass, highMass, PiMass, PiMass, type, beamConfigFile , Bslope);
 	
 	// seed the distribution with a sum of noninterfering s-wave amplitudes
 	// we can easily compute the PDF for this and divide by that when


### PR DESCRIPTION
Changed pi mass from 0.14 to 0.13957, so that hdgeant would not tag the events.