### PR TITLE
* fix compiler errors for g++ 4.8.5 [rtj]

### DIFF
--- a/src/programs/Simulation/gen_compton_simple/gen_compton_simple.cc
+++ b/src/programs/Simulation/gen_compton_simple/gen_compton_simple.cc
@@ -136,7 +136,7 @@ int main( int argc, char* argv[] ) {
     }
   }
 	
-  if (outname.size() == 0 && hddmname == 0) {
+  if ((int)outname.size() == 0 && hddmname == "") {
     cout << "No output specificed:  run gen_compton_simple -h for help" << endl;
     exit(1);
   }

--- a/src/programs/Simulation/gen_primex_eta_he4/gen_primex_eta_he4.cc
+++ b/src/programs/Simulation/gen_primex_eta_he4/gen_primex_eta_he4.cc
@@ -133,7 +133,7 @@ int main( int argc, char* argv[] ){
     }
   }
   
-  if (outname.size() == 0 && hddmname == 0) {
+  if (outname.size() == 0 && hddmname == "") {
     cout << "No output specificed:  run gen_compton_simple -h for help" << endl;
     exit(1);
   }

--- a/src/programs/Simulation/gen_whizard/gen_whizard.cc
+++ b/src/programs/Simulation/gen_whizard/gen_whizard.cc
@@ -140,7 +140,7 @@ int main( int argc, char* argv[] ){
     }
   }
   
-  if (outname.size() == 0 && hddmname == 0) {
+  if (outname.size() == 0 && hddmname == "") {
     cout << "No output specificed:  run gen_compton_simple -h for help" << endl;
     exit(1);
   }


### PR DESCRIPTION
   - disambiguate the test s==0 where s is a TString, replace with s==""