### PR TITLE
Add capability to provide a list of detectors whose hits we want to s…

### DIFF
--- a/src/programs/Simulation/mcsmear/MyProcessor.cc
+++ b/src/programs/Simulation/mcsmear/MyProcessor.cc
@@ -198,7 +198,7 @@ jerror_t MyProcessor::brun(JEventLoop *loop, int locRunNumber)
 	// load configuration parameters for all the detectors
 	if(smearer != NULL)
 		delete smearer;
-	smearer = new Smear(config, loop);
+	smearer = new Smear(config, loop, config->DETECTORS_TO_LOAD);
 
 #ifdef HAVE_RCDB
 	// Pull configuration parameters from RCDB
@@ -486,7 +486,7 @@ jerror_t MyProcessor::evnt(JEventLoop *loop, uint64_t eventnumber)
                    << std::endl;
       }
    }
-
+   
    // Smear values
    smearer->SmearEvent(record);
 

--- a/src/programs/Simulation/mcsmear/mcsmear.cc
+++ b/src/programs/Simulation/mcsmear/mcsmear.cc
@@ -105,7 +105,11 @@ void ParseCommandLineArguments(int narg, char* argv[], mcsmear_config_t *config)
           case 'm': config->APPLY_HITS_TRUNCATION=false;         break;
           case 'E': config->FCAL_ADD_LIGHTGUIDE_HITS=true;       break;
 	  case 'R': config->SKIP_READING_RCDB=true;              break;
-
+	 case 'l': {
+	   config->DETECTORS_TO_LOAD=&ptr[2];
+	   cout << "Detector list: " << config->DETECTORS_TO_LOAD << endl;  
+	   break;
+	 }
           // BCAL parameters
           case 'G': config->BCAL_NO_T_SMEAR = true;              break;
           case 'H': config->BCAL_NO_DARK_PULSES = true;          break;

--- a/src/programs/Simulation/mcsmear/mcsmear_config.h
+++ b/src/programs/Simulation/mcsmear/mcsmear_config.h
@@ -54,6 +54,9 @@ class mcsmear_config_t
 	double BCAL_NO_POISSON_STATISTICS;
 	double BCAL_NO_FADC_SATURATION;
 	double BCAL_NO_SIPM_SATURATION;
+
+	// list of detectors with hits to smear
+	string DETECTORS_TO_LOAD="all";
 	
 	
 #ifdef HAVE_RCDB

--- a/src/programs/Simulation/mcsmear/smear.cc
+++ b/src/programs/Simulation/mcsmear/smear.cc
@@ -52,7 +52,8 @@ Smear::Smear(mcsmear_config_t *in_config, JEventLoop *loop, string detectors_to_
     	std::istringstream ss(detectors_to_load);
     	std::string token;
     	while(std::getline(ss, token, ',')) {
-			DetectorSystem_t the_detector = static_cast<DetectorSystem_t>(atoi(token.c_str()));
+	  DetectorSystem_t the_detector=NameToSystem(token.c_str());
+	  //cout << "Loading detector system "<< the_detector << ":" << token << " " << endl;
 			switch(the_detector) {
 				case SYS_BCAL:   smearers[the_detector] = static_cast<Smearer*>(new BCALSmearer(loop,config));  break;
 				case SYS_FCAL:   smearers[the_detector] = static_cast<Smearer*>(new FCALSmearer(loop,config));  break;
@@ -96,7 +97,7 @@ void Smear::SmearEvent(hddm_s::HDDM *record)
 	// Smear each detector system
 	for(map<DetectorSystem_t, Smearer *>::iterator smearer_it = smearers.begin();
 		smearer_it != smearers.end(); smearer_it++) {
-        //cerr << "smearing " << SystemName(smearer_it->first) << endl;
+	  //cerr << "smearing " << SystemName(smearer_it->first) << endl;
 		smearer_it->second->SmearEvent(record);
     }
 


### PR DESCRIPTION
…mear on the command line.

The command line flag is -l followed by a comma separated list of detectors (case sensitive!).
For example: -lFDC,CDC,BCAL,FCAL .
This can be used for Primex-Eta simulations where the CDC/FDC detectors where not turned on but we still want the material to be present.