### PR TITLE
Make first event numbered 1 to avoid HDGeant renumbering 

### DIFF
--- a/src/libraries/AMPTOOLS_DATAIO/HDDMDataWriter.cc
+++ b/src/libraries/AMPTOOLS_DATAIO/HDDMDataWriter.cc
@@ -11,7 +11,7 @@ HDDMDataWriter::HDDMDataWriter(const string& outFile, int runNumber, int seed)
   m_OutputStream = new hddm_s::ostream(*m_OutputFile);
   m_runNumber = runNumber;
   
-  m_eventCounter = 0;
+  m_eventCounter = 1;
 
   // initialize root's pseudo-random generator
   gRandom->SetSeed(seed);


### PR DESCRIPTION
 I think that event 0 is being saved for meta-or-other-data