### PR TITLE
Gen amp development

### DIFF
--- a/src/libraries/AMPTOOLS_MCGEN/ProductionMechanism.cc
+++ b/src/libraries/AMPTOOLS_MCGEN/ProductionMechanism.cc
@@ -81,11 +81,14 @@ ProductionMechanism::produceResonance( const TLorentzVector& beam ){
   double exptMax = 1;   // remove factor of t for rho production (no spin flip). set this value for exp(Bt)
   
   double t, tMin, tMax, resMass, resMomCM;
-  
+
+  // First generate flat mass distribution
+  do // the resonance mass cannot be larger than CM energy - recoil mass
+    resMass = generateMass();
+  while ( cmEnergy < resMass + m_recMass );
+
+  // Then generate t accordingly
   do {
-    do // the resonance mass cannot be larger than CM energy - recoil mass
-      resMass = generateMass();
-    while ( cmEnergy < resMass + m_recMass );
     resMomCM  = cmMomentum( cmEnergy, resMass, m_recMass );
     
     tMin = 0;

--- a/src/libraries/UTILITIES/BeamProperties.cc
+++ b/src/libraries/UTILITIES/BeamProperties.cc
@@ -154,7 +154,7 @@ void BeamProperties::generateCobrems(){
 	string parameterNames[nParameters] = {"ElectronBeamEnergy", "CoherentPeakEnergy", "PhotonBeamLowEnergy", "PhotonBeamHighEnergy",  "Emittance", "RadiatorThickness", "CollimatorDiameter", "CollimatorDistance"};
 	for(int i=0; i<nParameters; i++) {
 		if(mBeamParametersMap.find(parameterNames[i].data()) == mBeamParametersMap.end()) {
-			cout << "BeamProperties WANRNING:  generateCombrems parameter " << parameterNames[i] << " missing: using default = " << defaultParameters.at(parameterNames[i].data()) << endl;
+			cout << "BeamProperties WARNING:  generateCombrems parameter " << parameterNames[i] << " missing: using default = " << defaultParameters.at(parameterNames[i].data()) << endl;
 			mBeamParametersMap.insert( std::pair<std::string,double>( parameterNames[i].data(), defaultParameters.at(parameterNames[i].data())) );
 		}
 	}


### PR DESCRIPTION
If the beam energy is large enough to produce the full mass range, the resulting mass distribution is now truly flat when generated with '-f'. If not, a warning will be generated. The new diagnostics histogram with mass vs energy will illustrate possible problems.