### PR TITLE
Simulate realistic vertex distribution with gen_amp

### DIFF
--- a/src/libraries/AMPTOOLS_DATAIO/HDDMDataWriter.cc
+++ b/src/libraries/AMPTOOLS_DATAIO/HDDMDataWriter.cc
@@ -29,7 +29,8 @@ void HDDMDataWriter::
 writeEvent( const Kinematics& kin, const vector<int>& ptype, bool centeredVertex)
 {
   if (centeredVertex)
-    writeEvent(kin,ptype,0,0,65/*cm*/);
+    // this will trigger hdgeant(4) to generate the vertex distribution
+    writeEvent(kin,ptype,0,0,0/*cm*/);
   else
     writeEvent(kin,ptype,0,0,50/*cm*/,80/*cm*/);
 }

--- a/src/programs/Simulation/gen_amp/gen_amp.cc
+++ b/src/programs/Simulation/gen_amp/gen_amp.cc
@@ -52,6 +52,7 @@ int main( int argc, char* argv[] ){
 	string  outname("");
 	string  hddmname("");
 	
+	bool centeredVertex = false;
 	bool diag = false;
 	bool genFlat = false;
 	
@@ -126,6 +127,8 @@ int main( int argc, char* argv[] ){
                         else  highT = atof( argv[++i] ); }
 		if (arg == "-d"){
 			diag = true; }
+		if (arg == "-v"){
+			centeredVertex = true; }
 		if (arg == "-f"){
 			genFlat = true; }
 		if (arg == "-h"){
@@ -145,6 +148,7 @@ int main( int argc, char* argv[] ){
 			cout << "\t -t    <value>\t Momentum transfer slope [optional]" << endl;
 			cout << "\t -tmin <value>\t Minimum momentum transfer [optional]" << endl;
 			cout << "\t -tmax <value>\t Maximum momentum transfer [optional]" << endl;
+			cout << "\t -v \t\t Set vertex to (0,0,0), i.e. let geant generate vertex distribution [optional]" << endl;
 			cout << "\t -f \t\t Generate flat in M(X) (no physics) [optional]" << endl;
 			cout << "\t -d \t\t Plot only diagnostic histograms [optional]" << endl << endl;
 			exit(1);
@@ -457,7 +461,7 @@ int main( int argc, char* argv[] ){
 					// we want to save events with weight 1
 					evt->setWeight( 1.0 );
 					
-					if( hddmOut ) hddmOut->writeEvent( *evt, pTypes );
+					if( hddmOut ) hddmOut->writeEvent( *evt, pTypes, centeredVertex );
 					rootOut.writeEvent( *evt );
 					++eventCounter;
 					if(eventCounter >= nEvents) break;


### PR DESCRIPTION
Set the centeredVertex switch to (0,0,0), which will trigger hdgeant(4) to generate a vertex distribution. This feature is available with '-v' in gen_amp.