### PR TITLE
* fix the energy scale of the dE in the tof hits so that the reference

### DIFF
--- a/src/programs/Simulation/mcsmear/TOFSmearer.cc
+++ b/src/programs/Simulation/mcsmear/TOFSmearer.cc
@@ -32,8 +32,10 @@ tof_config_t::tof_config_t(JEventLoop *loop)
      	return;
     }
      	
-    TOF_SIGMA =  tofparms["TOF_SIGMA"];
-    TOF_PHOTONS_PERMEV =  tofparms["TOF_PHOTONS_PERMEV"];
+    TOF_SIGMA =  tofparms.at("TOF_SIGMA");
+    TOF_PHOTONS_PERMEV =  tofparms.at("TOF_PHOTONS_PERMEV");
+    ATTENUATION_LENGTH = tofparms.at("TOF_ATTEN_LENGTH");
+    FULL_BAR_LENGTH = tofparms.at("TOF_PADDLE_LENGTH");
 	
     string locTOFPaddleResolTable = TOFGeom[0]->Get_CCDB_DirectoryName() + "/paddle_resolutions";
 	cout<<"get "<<locTOFPaddleResolTable<<" from calibDB"<<endl;
@@ -148,6 +150,8 @@ void TOFSmearer::SmearEvent(hddm_s::HDDM *record)
          	 npe += gDRandom.SampleGaussian(sqrt(npe));
           	 NewE = npe/tof_config->TOF_PHOTONS_PERMEV/1000.;
 		 }
+         // Apply an average attenuation correction to set the energy scale
+         NewE *= exp(tof_config->FULL_BAR_LENGTH / 2 / tof_config->ATTENUATION_LENGTH);
          if (NewE > tof_config->TOF_BAR_THRESHOLD) {
             hddm_s::FtofHitList hits = iter->addFtofHits();
             hits().setEnd(titer->getEnd());

--- a/src/programs/Simulation/mcsmear/TOFSmearer.h
+++ b/src/programs/Simulation/mcsmear/TOFSmearer.h
@@ -27,6 +27,8 @@ class tof_config_t
 	double TOF_SIGMA;
 	double TOF_PHOTONS_PERMEV;
 	double TOF_BAR_THRESHOLD;
+    double ATTENUATION_LENGTH;
+    double FULL_BAR_LENGTH;
 
   	vector<double> TOF_PADDLE_TIME_RESOLUTIONS;
 	


### PR DESCRIPTION
  point where attenuation factor=1 is the middle of the paddle to agree
  with how the correction is applied in DTOFPoint_factory.cc, instead
  of at the end closest to the tube, where it is in the simulation. [rtj]