### PR TITLE
Declare itrack static to limit scope to the source file.

### DIFF
--- a/src/programs/Simulation/HDGeant/hitCDC.c
+++ b/src/programs/Simulation/HDGeant/hitCDC.c
@@ -53,7 +53,7 @@ static float cdc_drift_distance[78];
 static float BSCALE_PAR1=0.;
 static float BSCALE_PAR2=0.;
 
-int itrack;
+static int itrack;
 
 /* void GetDOCA(int ipart, float x[3], float p[5], float doca[3]);  disabled 6/24/2009 */
 

--- a/src/programs/Simulation/HDGeant/hitFDC.c
+++ b/src/programs/Simulation/HDGeant/hitFDC.c
@@ -32,7 +32,7 @@ typedef struct{
 
 extern controlparams_t controlparams_;
 
-int itrack;
+static int itrack;
 
 const float wire_dead_zone_radius[4]={3.0,3.0,3.9,3.9};
 const float strip_dead_zone_radius[4]={1.3,1.3,1.3,1.3};


### PR DESCRIPTION
With the scope limited to a single file, the itrack variable does not appear as a duplicated global variable to the linker for GCC 10.1.1. Fix suggested by @rjones30 , who is requested as a reviewer.