### PR TITLE
Guard against no flux entries in CCDB

### DIFF
--- a/src/libraries/UTILITIES/BeamProperties.cc
+++ b/src/libraries/UTILITIES/BeamProperties.cc
@@ -364,6 +364,11 @@ void BeamProperties::fillFluxFromCCDB() {
 		if(accept < 0.01) flux = 0; // remove very low acceptance regions to avoid fluctuations
 		fluxVsEgamma->Fill(energy, flux);
 	}
+
+	if (fluxVsEgamma->Integral() == 0){
+	  cout << "ERROR: Flux in CCDB not available for this energy range!" << endl;
+	  exit(101);
+	}
 	
 	return;
 }


### PR DESCRIPTION
If there is no flux in ccdb, the histogram of the energy spectrum is empty. Most generators use GetRandom() on this histogram to get the beam energy, which returns 0 and may cause infinite loops in the generation of 4-vectors. This PR prints an error message and terminates the process with error code 101, which is understood by MCWrapper.