### PR TITLE
added an exit condition if there are no accepted events in 10M genera…

### DIFF
--- a/src/programs/Simulation/genr8/genr8.cc
+++ b/src/programs/Simulation/genr8/genr8.cc
@@ -472,6 +472,12 @@ int main(int argc,char **argv)
   if(Y->nchildren == 0) Y->mass = Y->bookmass;
  
   while(naccepted <max){
+    
+    if(naccepted==0 && ngenerated>10000000)
+    {
+      fprintf(stderr,"No accepted events in 10 Million generated events.  Exiting to avoid probable infinite loop. \n");
+      exit(-1);
+    }
 
     if (Debug) fprintf(stderr,"In main do loop ... %d \n",naccepted);
     struct particleMC_t event_beam, event_target;


### PR DESCRIPTION
One of the most common infinite loops in the whole MC pipeline is a miss configured genr8 which leads to generating an infinite number of events without any being accepted.  This PR adds in a check and exits with a non 0 status code if exactly 0 events are accepted in 10 million generated events.