### PR TITLE
Correct bug and add 3rd option

### DIFF
--- a/src/programs/Simulation/gen_primex_compton/compton.temp
+++ b/src/programs/Simulation/gen_primex_compton/compton.temp
@@ -1,6 +1,12 @@
 #Run Compton PRIMEX true/false
 run: BOOL
 
+#Options
+#0 use egam
+#1 use one tagger counter energy
+#Not 0 or 1, use all tagger counter energies
+option: 0
+
 #Electron energy
 #11.6061 GeV (Be)
 #11.1671 GeV (He)

--- a/src/programs/Simulation/gen_primex_compton/gen_primex_compton.cc
+++ b/src/programs/Simulation/gen_primex_compton/gen_primex_compton.cc
@@ -175,6 +175,7 @@ int main( int argc, char* argv[] ){
   TString m_shell = ReadFile->GetConfigName("shell");
   Double_t * m_Ee = ReadFile->GetConfig1Par("Ee");  
   TString m_tagger_file = ReadFile->GetConfigName("tagger_file");
+  TString m_option = ReadFile->GetConfigName("option");
 
   TFile * diagOut = new TFile( TString::Format("gen_primex_compton_runnb_%d.root", runNum), "recreate" );
   TH1F * h_egam1 = new TH1F("egam1", ";E_{#gamma} [GeV];Count/MeV", 12000, 0.0, 12.0);
@@ -206,21 +207,21 @@ int main( int argc, char* argv[] ){
 	tagger_channel_nb = 274;
 
       if (m_workflow != "" && m_shell == "bash")
-	system(TString::Format("source $HALLD_SIM_HOME/src/programs/Simulation/gen_primex_compton/run/compton_slurm.sh %s %f %d %d %d %s %s %d", 
+	system(TString::Format("source $HALLD_SIM_HOME/src/programs/Simulation/gen_primex_compton/run/compton_slurm.sh %s %f %d %d %d %s %s %d %d", 
 			       //m_out_dir.Data(), (int) egam, nbofevt, runNum, runNum, m_workflow.Data()));
-			       m_out_dir.Data(), m_Ee[0], nEvents, runNum, runNum, m_workflow.Data(), m_tagger_file.Data(), tagger_channel_nb));
+			       m_out_dir.Data(), m_Ee[0], nEvents, runNum, runNum, m_workflow.Data(), m_tagger_file.Data(), tagger_channel_nb, m_option[0]));
       else if (m_workflow != "" && m_shell == "tcsh")
-	system(TString::Format("source $HALLD_SIM_HOME/src/programs/Simulation/gen_primex_compton/run/compton_slurm.csh %s %f %d %d %d %s %s %d", 
+	system(TString::Format("source $HALLD_SIM_HOME/src/programs/Simulation/gen_primex_compton/run/compton_slurm.csh %s %f %d %d %d %s %s %d %d", 
 			       //m_out_dir.Data(), (int) egam, nbofevt, runNum, runNum, m_workflow.Data()));
-			       m_out_dir.Data(), m_Ee[0], nEvents, runNum, runNum, m_workflow.Data(), m_tagger_file.Data(), tagger_channel_nb));
+			       m_out_dir.Data(), m_Ee[0], nEvents, runNum, runNum, m_workflow.Data(), m_tagger_file.Data(), tagger_channel_nb, m_option[0]));
       else if (m_workflow == "" && m_shell == "bash")
-	system(TString::Format("source $HALLD_SIM_HOME/src/programs/Simulation/gen_primex_compton/run/compton_prompt.sh %s %f %d %d %d %s %d", 
+	system(TString::Format("source $HALLD_SIM_HOME/src/programs/Simulation/gen_primex_compton/run/compton_prompt.sh %s %f %d %d %d %s %d %d", 
 			       //m_out_dir.Data(), (int) egam, nbofevt, runNum, runNum));
-			       m_out_dir.Data(), m_Ee[0], nEvents, runNum, runNum, m_tagger_file.Data(), tagger_channel_nb));
+			       m_out_dir.Data(), m_Ee[0], nEvents, runNum, runNum, m_tagger_file.Data(), tagger_channel_nb, m_option[0]));
       else if (m_workflow == "" && m_shell == "tcsh")
-	system(TString::Format("source $HALLD_SIM_HOME/src/programs/Simulation/gen_primex_compton/run/compton_prompt.sh %s %f %d %d %d %s %d", 
+	system(TString::Format("source $HALLD_SIM_HOME/src/programs/Simulation/gen_primex_compton/run/compton_prompt.sh %s %f %d %d %d %s %d %d", 
 			       //m_out_dir.Data(), (int) egam, nbofevt, runNum, runNum));
-			       m_out_dir.Data(), m_Ee[0], nEvents, runNum, runNum, m_tagger_file.Data(), tagger_channel_nb));
+			       m_out_dir.Data(), m_Ee[0], nEvents, runNum, runNum, m_tagger_file.Data(), tagger_channel_nb, m_option[0]));
     }
     
     for (int i = 0; i < h_egam1->GetNbinsX(); i ++) { //Generate LHE file
@@ -228,19 +229,19 @@ int main( int argc, char* argv[] ){
       int nbofevt =  h_egam1->GetBinContent(i + 1);
       if (nbofevt > 0) {
 	if (m_workflow != "" && m_shell == "bash")
-	  system(TString::Format("source $HALLD_SIM_HOME/src/programs/Simulation/gen_primex_compton/run/compton_slurm.sh %s %f %d %d %d %s test 0", 
+	  system(TString::Format("source $HALLD_SIM_HOME/src/programs/Simulation/gen_primex_compton/run/compton_slurm.sh %s %f %d %d %d %s test 0 0", 
 				 //m_out_dir.Data(), (int) egam, nbofevt, runNum, runNum, m_workflow.Data()));
 				 m_out_dir.Data(), egam, nbofevt, runNum, runNum, m_workflow.Data()));
 	else if (m_workflow != "" && m_shell == "tcsh")
-	  system(TString::Format("source $HALLD_SIM_HOME/src/programs/Simulation/gen_primex_compton/run/compton_slurm.csh %s %f %d %d %d %s test 0", 
+	  system(TString::Format("source $HALLD_SIM_HOME/src/programs/Simulation/gen_primex_compton/run/compton_slurm.csh %s %f %d %d %d %s test 0 0", 
 				 //m_out_dir.Data(), (int) egam, nbofevt, runNum, runNum, m_workflow.Data()));
 				 m_out_dir.Data(), egam, nbofevt, runNum, runNum, m_workflow.Data()));
 	else if (m_workflow == "" && m_shell == "bash")
-	  system(TString::Format("source $HALLD_SIM_HOME/src/programs/Simulation/gen_primex_compton/run/compton_prompt.sh %s %f %d %d %d test 0", 
+	  system(TString::Format("source $HALLD_SIM_HOME/src/programs/Simulation/gen_primex_compton/run/compton_prompt.sh %s %f %d %d %d test 0 0", 
 				 //m_out_dir.Data(), (int) egam, nbofevt, runNum, runNum));
 				 m_out_dir.Data(), egam, nbofevt, runNum, runNum));
 	else if (m_workflow == "" && m_shell == "tcsh")
-	  system(TString::Format("source $HALLD_SIM_HOME/src/programs/Simulation/gen_primex_compton/run/compton_prompt.sh %s %f %d %d %d test 0", 
+	  system(TString::Format("source $HALLD_SIM_HOME/src/programs/Simulation/gen_primex_compton/run/compton_prompt.sh %s %f %d %d %d test 0 0", 
 				 //m_out_dir.Data(), (int) egam, nbofevt, runNum, runNum));
 				 m_out_dir.Data(), egam, nbofevt, runNum, runNum));
       }

--- a/src/programs/Simulation/gen_primex_compton/run/compton_prompt.csh
+++ b/src/programs/Simulation/gen_primex_compton/run/compton_prompt.csh
@@ -18,6 +18,7 @@ set runnb_max=$5
 set wf=$6
 set filename=$7
 set linenumber=$8
+set opt=$9
 
 set store=$path/run_${runnb_min}_${runnb_max}_egam_${egam}GeV
 
@@ -34,7 +35,7 @@ config=bases-init.dbf
 set run=$store/$file.sh
 echo '#source /work/halld/home/ijaegle/Env/custom_GlueX_dev.sh' > $run
 echo "cd ${store}" >> $run
-echo "sd_compton ${config} ${file} ${egam} ${evtnb} ${filename} ${linenumber}> ${file}.log" >> $run
+echo "sd_compton ${config} ${file} ${egam} ${evtnb} ${filename} ${linenumber} ${opt} > ${file}.log" >> $run
 echo "h2root ${file}.hbook" >> $run
 echo "rm ${file}.bin ${file}.dat ${file}.hbook" >> $run
 source $run

--- a/src/programs/Simulation/gen_primex_compton/run/compton_prompt.sh
+++ b/src/programs/Simulation/gen_primex_compton/run/compton_prompt.sh
@@ -17,6 +17,7 @@ runnb_min=$4
 runnb_max=$5
 filename=$7
 linenumber=$8
+opt=$9
 
 store=$path/run_${runnb_min}_${runnb_max}_egam_${egam}GeV
 
@@ -33,7 +34,7 @@ config=bases-init.dbf
 run=$store/$file.sh
 echo '#source /work/halld/home/ijaegle/Env/custom_GlueX_dev.sh' > $run
 echo "cd ${store}" >> $run
-echo "sd_compton ${config} ${file} ${egam} ${evtnb} ${filename} ${linenumber} > ${file}.log" >> $run
+echo "sd_compton ${config} ${file} ${egam} ${evtnb} ${filename} ${linenumber} ${opt} > ${file}.log" >> $run
 echo "h2root ${file}.hbook" >> $run
 echo "rm ${file}.bin ${file}.dat ${file}.hbook" >> $run
 source $run

--- a/src/programs/Simulation/gen_primex_compton/run/compton_slurm.csh
+++ b/src/programs/Simulation/gen_primex_compton/run/compton_slurm.csh
@@ -18,6 +18,7 @@ set runnb_max=$5
 set wf=$6
 set filename=$7
 set linenumber=$8
+set opt=$9
 
 set store=$path/run_${runnb_min}_${runnb_max}_egam_${egam}GeV
 
@@ -34,7 +35,7 @@ config=bases-init.dbf
 set run=$store/$file.sh
 echo 'source /work/halld/home/ijaegle/Env/custom_GlueX_dev.sh' > $run
 echo "cd ${store}" >> $run
-echo "sd_compton ${config} ${file} ${egam} ${evtnb} ${filename} ${linenumber} > ${file}.log" >> $run
+echo "sd_compton ${config} ${file} ${egam} ${evtnb} ${filename} ${linenumber} ${opt} > ${file}.log" >> $run
 echo "h2root ${file}.hbook" >> $run
 echo "rm ${file}.bin ${file}.dat ${file}.hbook" >> $run
 chmod +x $run

--- a/src/programs/Simulation/gen_primex_compton/run/compton_slurm.sh
+++ b/src/programs/Simulation/gen_primex_compton/run/compton_slurm.sh
@@ -18,6 +18,7 @@ runnb_max=$5
 wf=$6
 filename=$7
 linenumber=$8
+opt=$9
 
 store=$path/run_${runnb_min}_${runnb_max}_egam_${egam}GeV
 
@@ -34,7 +35,7 @@ config=bases-init.dbf
 run=$store/$file.sh
 echo 'source /work/halld/home/ijaegle/Env/custom_GlueX_dev.sh' > $run
 echo "cd ${store}" >> $run
-echo "sd_compton ${config} ${file} ${egam} ${evtnb} ${filename} ${linenumber} > ${file}.log" >> $run
+echo "sd_compton ${config} ${file} ${egam} ${evtnb} ${filename} ${linenumber} ${opt} > ${file}.log" >> $run
 echo "h2root ${file}.hbook" >> $run
 echo "rm ${file}.bin ${file}.dat ${file}.hbook" >> $run
 chmod +x $run

--- a/src/programs/Simulation/gen_primex_compton/run/run_sd_compton.cc
+++ b/src/programs/Simulation/gen_primex_compton/run/run_sd_compton.cc
@@ -70,6 +70,9 @@ int main(int argc, char * argv[]) {
   Double_t * beamLowE = ReadFile->GetConfig1Par("PhotonBeamLowEnergy");
   Double_t * beamHighE = ReadFile->GetConfig1Par("PhotonBeamHighEnergy");
   cout << " beamLowE " << beamLowE[0] << " GeV beamHighE " << beamHighE[0] << endl;
+  //Double_t * m_Ee = ReadFile->GetConfig1Par("Ee");  
+  //TString m_tagger_file = ReadFile->GetConfigName("tagger_file");
+  //TString m_option = ReadFile->GetConfigName("option");
   
   if (m_histoname == "FLUXNAME") 
     m_rootfile = "";
@@ -111,19 +114,19 @@ int main(int argc, char * argv[]) {
     if (nbofevt > 0) {
       //egam *= 1e3;
       if (strcmp(shell,"tcsh") == 0 && iswf == 0)
-	system(TString::Format("source $HALLD_SIM_HOME/src/programs/Simulation/gen_primex_compton/run/compton_prompt.sh %s %f %d %d %d", 
+	system(TString::Format("source $HALLD_SIM_HOME/src/programs/Simulation/gen_primex_compton/run/compton_prompt.sh %s %f %d %d %d test 0 0", 
 			       //out_dir, (int) egam, nbofevt, run_nb_min, run_nb_max));
 			       out_dir, egam, nbofevt, run_nb_min, run_nb_max));
       else if (strcmp(shell,"tcsh") == 0 && iswf == 1)
-	system(TString::Format("source $HALLD_SIM_HOME/src/programs/Simulation/gen_primex_compton/run/compton_slurm.csh %s %f %d %d %d %s", 
+	system(TString::Format("source $HALLD_SIM_HOME/src/programs/Simulation/gen_primex_compton/run/compton_slurm.csh %s %f %d %d %d %s test 0 0", 
 			       //out_dir, (int) egam, nbofevt, run_nb_min, run_nb_max, workflow));
 			       out_dir, egam, nbofevt, run_nb_min, run_nb_max, workflow));
       else if (strcmp(shell,"bash") == 0 && iswf == 0)
-	system(TString::Format("source $HALLD_SIM_HOME/src/programs/Simulation/gen_primex_compton/run/compton_prompt.sh %s %f %d %d %d", 
+	system(TString::Format("source $HALLD_SIM_HOME/src/programs/Simulation/gen_primex_compton/run/compton_prompt.sh %s %f %d %d %d test 0 0", 
 			       //out_dir, (int) egam, nbofevt, run_nb_min, run_nb_max));
 			       out_dir, egam, nbofevt, run_nb_min, run_nb_max));
       else if (strcmp(shell,"bash") == 0 && iswf == 1)
-	system(TString::Format("source $HALLD_SIM_HOME/src/programs/Simulation/gen_primex_compton/run/compton_slurm.sh %s %f %d %d %d %s", 
+	system(TString::Format("source $HALLD_SIM_HOME/src/programs/Simulation/gen_primex_compton/run/compton_slurm.sh %s %f %d %d %d %s test 0 0", 
 			       //out_dir, (int) egam, nbofevt, run_nb_min, run_nb_max, workflow));
 			       out_dir, egam, nbofevt, run_nb_min, run_nb_max, workflow));
       npts ++;

--- a/src/programs/Simulation/gen_primex_compton/sd_compton/constants.inc
+++ b/src/programs/Simulation/gen_primex_compton/sd_compton/constants.inc
@@ -71,8 +71,8 @@ C
 	REAL*8 acc2
 	INTEGER*4 mxevnt
         REAL*8 eg
-	INTEGER*8 chnb
-        REAL*8 evtnb
+	INTEGER*4 chnb
+        INTEGER*4 evtnb
 C
 	REAL*8 xl
 	REAL*8 xu

--- a/src/programs/Simulation/gen_primex_compton/sd_compton/sd_compton.F
+++ b/src/programs/Simulation/gen_primex_compton/sd_compton/sd_compton.F
@@ -29,6 +29,8 @@ C
 C
 	integer      iargc
 C
+	integer opt
+C
 	integer*4    lenocc
 	external     lenocc
 C
@@ -41,6 +43,7 @@ C
 	character*20 str_eg
 	character*20 str_evtnb
 	character*20 str_chnb
+	character*20 str_opt
 	character*80 infile
 	character*80 tagfile
 	character*80 outfile
@@ -57,8 +60,11 @@ C
 	save pos
 	data pos /1/
 C
-        if (iargc().NE.6) then
-	   print*, '===> USAGE: comprc inputfile outfile egam [GeV] evtnb tagfile chnb<==='
+        if (iargc().NE.7) then
+	   print*, '===> USAGE: comprc inputfile outfile egam [GeV] evtnb tagfile chnb opt<==='
+	   print*, '            if opt=0 use egam'
+	   print*, '            if opt=1 use etag(chnb)'
+	   print*, '            if opt not 0 or 1 use all etag(i)'
 	   stop
 	endif
 	call getarg(1,infile)
@@ -67,16 +73,24 @@ C
 	call getarg(4,str_evtnb)
 	call getarg(5,tagfile)
 	call getarg(6,str_chnb)
+	call getarg(7,str_opt)
 	read(str_Eg,*) eg
 	read(str_evtnb,*) evtnb
 	read(str_chnb,*) chnb
+	read(str_opt,*) opt
  1000	format(I3)
 C
 	call hlimit(iPawSize)
 	call init_parms(infile)
 C
+	print*,'infile ',infile
+	print*,'outfile ',outfile
+	print*,'str_eg ',eg
+	print*,'str_evtnb ',evtnb
+	print*,'str_chnb ',chnb
+C
 	if (chnb>0) then
-	print*,'tagfile ',tagfile,' ch nb ',chnb
+	   print*,'tagfile ',tagfile,' ch nb ',chnb
 	   open(20, file=tagfile,form='formatted', status='old')
 	   do i = 1, chnb
 	      read(20,'(1(i6,1x),5(x,F15.6))')ic,tmin,tmax
@@ -86,8 +100,15 @@ C
 	   enddo
 	   close(20)
 	endif
-	if (chnb==0) then
+	if (opt==0) then
+	   chnb = 1
 	   etag(1) = eg 
+	   print*,'no tagfile ',tagfile,' ch nb ',chnb, ' eg ',eg
+	endif
+	if (opt==1) then
+	   etag(1) = etag(chnb)
+	   chnb = 1
+	   print*,'no tagfile ',tagfile,' ch nb ',chnb, ' eg ',eg
 	endif
 C       
 	ipos = index(outfile,'.')


### PR DESCRIPTION
I corrected the bug in the previous version and added a 3rd option
1/  sd_compton  bases-init.dbf test 8.9 1000 primex_tagm.txt 0 0 -> will run one single energy at 8.9GeV
2/ sd_compton  bases-init.dbf test 11.606 100 primex_tagm.txt 40 1 -> will run one single energy corresponding microscope channel 40
3/ sd_compton  bases-init.dbf test 11.606 100 primex_tagm.txt 40 2 -> will run 40 different energies corresponding to microscope channel 1 to 40