### PR TITLE
Add option to not merge tagger background hits

### DIFF
--- a/src/programs/Simulation/mcsmear/MyProcessor.cc
+++ b/src/programs/Simulation/mcsmear/MyProcessor.cc
@@ -472,7 +472,7 @@ jerror_t MyProcessor::evnt(JEventLoop *loop, uint64_t eventnumber)
    hddm_s::HDDM *record = (hddm_s::HDDM*)event.GetRef();
    if (!record)
       return NOERROR;
-
+ 
    // Handle geometry records
    hddm_s::GeometryList geom = record->getGeometrys();
    if (geom.size() > 0) {
@@ -512,6 +512,9 @@ jerror_t MyProcessor::evnt(JEventLoop *loop, uint64_t eventnumber)
             //pthread_mutex_unlock(&input_file_mutex);
          }
          
+         if(config->MERGE_TAGGER_HITS == false) {
+         	hddm_s_merger::set_tag_merging(false);
+         }
          hddm_s_merger::set_t_shift_ns(0);
          hddm_s::RFsubsystemList RFtimes = record2.getRFsubsystems();
          hddm_s::RFsubsystemList::iterator RFiter;

--- a/src/programs/Simulation/mcsmear/TOFSmearer.cc
+++ b/src/programs/Simulation/mcsmear/TOFSmearer.cc
@@ -115,9 +115,7 @@ tof_config_t::tof_config_t(JEventLoop *loop)
 	}
 #endif // DTOFGEOMETRY_VERSION
 
-	cout << "****************************************" << endl;
-	cout << "TOF BARS = " << TOF_NUM_BARS << endl;
-	cout << "****************************************" << endl;
+	cout << "Number of TOF bars per plane = " << TOF_NUM_BARS << endl;
 }
 
 

--- a/src/programs/Simulation/mcsmear/hddm_s_merger.cc
+++ b/src/programs/Simulation/mcsmear/hddm_s_merger.cc
@@ -28,19 +28,23 @@ const double fadc250_period_ns(4.);
 
 static thread_local double t_shift_ns(0);
 
+static thread_local bool   enable_cdc_merging(true);
 static thread_local int    cdc_max_hits(1);
 static thread_local double cdc_integration_window_ns(800.);
 
+static thread_local bool   enable_fdc_merging(true);
 static thread_local int    fdc_wires_max_hits(8);
 static thread_local double fdc_wires_min_delta_t_ns(35.);
 static thread_local int    fdc_strips_max_hits(1);
 static thread_local double fdc_strips_integration_window_ns(200.);
 
+static thread_local bool   enable_stc_merging(true);
 static thread_local int    stc_adc_max_hits(3);
 static thread_local int    stc_tdc_max_hits(8);
 static thread_local double stc_min_delta_t_ns(25.);
 static thread_local double stc_integration_window_ns(100.);
 
+static thread_local bool   enable_bcal_merging(true);
 static thread_local int    bcal_adc_max_hits(1);
 static thread_local int    bcal_tdc_max_hits(8);
 static thread_local double bcal_min_delta_t_ns(25.);
@@ -48,40 +52,56 @@ static thread_local double bcal_integration_window_ns(114.);
 static thread_local double bcal_fadc_counts_per_ns(16.);
 static thread_local double bcal_tdc_counts_per_ns(16.13);
 
+static thread_local bool   enable_ftof_merging(true);
 static thread_local int    ftof_adc_max_hits(3);
 static thread_local int    ftof_tdc_max_hits(64);
 static thread_local double ftof_min_delta_t_ns(25.);
 static thread_local double ftof_integration_window_ns(104.);
 
+static thread_local bool   enable_fcal_merging(true);
 static thread_local int    fcal_max_hits(3);
 static thread_local double fcal_min_delta_t_ns(70.);
 static thread_local double fcal_integration_window_ns(64.);
 
+static thread_local bool   enable_ccal_merging(true);
 static thread_local int    ccal_max_hits(3);
 static thread_local double ccal_min_delta_t_ns(70.);
 static thread_local double ccal_integration_window_ns(64.);
 
+static thread_local bool   enable_ps_merging(true);
 static thread_local int    ps_max_hits(3);
 static thread_local double ps_integration_window_ns(72.);
+static thread_local bool   enable_psc_merging(true);
 static thread_local int    psc_adc_max_hits(3);
 static thread_local int    psc_tdc_max_hits(3);
 static thread_local double psc_min_delta_t_ns(25.);
 static thread_local double psc_integration_window_ns(36.);
 
+static thread_local bool   enable_tag_merging(true);
 static thread_local int    tag_adc_max_hits(3);
 static thread_local int    tag_tdc_max_hits(8);
 static thread_local double tag_min_delta_t_ns(25.);
 static thread_local double tag_integration_window_ns(36.);
 
+static thread_local bool   enable_tpol_merging(true);
 static thread_local int    tpol_max_hits(1);
 static thread_local double tpol_integration_window_ns(2500.);
 
+static thread_local bool   enable_fmwpc_merging(true);
 static thread_local int    fmwpc_max_hits(1);
 static thread_local double fmwpc_min_delta_t_ns(400.);
 
 extern const mcsmear_config_t *mcsmear_config;
 
 namespace hddm_s_merger {
+
+   bool get_cdc_merging() {
+      return enable_cdc_merging;
+   }
+   
+   void set_cdc_merging(bool merging_status) {
+      enable_cdc_merging = merging_status;
+   }
 
    double get_t_shift_ns() {
       return t_shift_ns;
@@ -105,6 +125,14 @@ namespace hddm_s_merger {
 
    void set_cdc_integration_window_ns(double dt_ns) {
       cdc_integration_window_ns = dt_ns;
+   }
+
+   bool get_fdc_merging() {
+      return enable_fdc_merging;
+   }
+   
+   void set_fdc_merging(bool merging_status) {
+      enable_fdc_merging = merging_status;
    }
 
    int get_fdc_wires_max_hits() {
@@ -139,6 +167,14 @@ namespace hddm_s_merger {
       fdc_strips_integration_window_ns = dt_ns;
    }
 
+   bool get_stc_merging() {
+      return enable_stc_merging;
+   }
+   
+   void set_stc_merging(bool merging_status) {
+      enable_stc_merging = merging_status;
+   }
+
    int get_stc_adc_max_hits() {
       return stc_adc_max_hits;
    }
@@ -169,6 +205,14 @@ namespace hddm_s_merger {
 
    void set_stc_integration_window_ns(double dt_ns) {
       stc_integration_window_ns = dt_ns;
+   }
+
+   bool get_bcal_merging() {
+      return enable_bcal_merging;
+   }
+   
+   void set_bcal_merging(bool merging_status) {
+      enable_bcal_merging = merging_status;
    }
 
    int get_bcal_adc_max_hits() {
@@ -219,6 +263,14 @@ namespace hddm_s_merger {
       bcal_tdc_counts_per_ns = slope;
    }
 
+   bool get_ftof_merging() {
+      return enable_ftof_merging;
+   }
+   
+   void set_ftof_merging(bool merging_status) {
+      enable_ftof_merging = merging_status;
+   }
+
    int get_ftof_adc_max_hits() {
       return ftof_adc_max_hits;
    }
@@ -251,6 +303,14 @@ namespace hddm_s_merger {
       ftof_integration_window_ns = dt_ns;
    }
 
+   bool get_fcal_merging() {
+      return enable_fcal_merging;
+   }
+   
+   void set_fcal_merging(bool merging_status) {
+      enable_fcal_merging = merging_status;
+   }
+
    int get_fcal_max_hits() {
       return fcal_max_hits;
    }
@@ -273,6 +333,14 @@ namespace hddm_s_merger {
 
    void set_fcal_integration_window_ns(double dt_ns) {
       fcal_integration_window_ns = dt_ns;
+   }
+
+   bool get_ccal_merging() {
+      return enable_ccal_merging;
+   }
+   
+   void set_ccal_merging(bool merging_status) {
+      enable_ccal_merging = merging_status;
    }
 
    int get_ccal_max_hits() {
@@ -299,6 +367,14 @@ namespace hddm_s_merger {
       ccal_integration_window_ns = dt_ns;
    }
 
+   bool get_ps_merging() {
+      return enable_ps_merging;
+   }
+   
+   void set_ps_merging(bool merging_status) {
+      enable_ps_merging = merging_status;
+   }
+
    int get_ps_max_hits() {
       return ps_max_hits;
    }
@@ -313,6 +389,14 @@ namespace hddm_s_merger {
 
    void set_ps_integration_window_ns(double dt_ns) {
       ps_integration_window_ns = dt_ns;
+   }
+
+   bool get_psc_merging() {
+      return enable_psc_merging;
+   }
+   
+   void set_psc_merging(bool merging_status) {
+      enable_psc_merging = merging_status;
    }
 
    int get_psc_adc_max_hits() {
@@ -347,6 +431,14 @@ namespace hddm_s_merger {
       psc_integration_window_ns = dt_ns;
    }
 
+   bool get_tag_merging() {
+      return enable_tag_merging;
+   }
+   
+   void set_tag_merging(bool merging_status) {
+      enable_tag_merging = merging_status;
+   }
+
    int get_tag_adc_max_hits() {
       return tag_adc_max_hits;
    }
@@ -379,6 +471,14 @@ namespace hddm_s_merger {
       tag_integration_window_ns = dt_ns;
    }
 
+   bool get_tpol_merging() {
+      return enable_tpol_merging;
+   }
+   
+   void set_tpol_merging(bool merging_status) {
+      enable_tpol_merging = merging_status;
+   }
+
    int get_tpol_max_hits() {
       return tpol_max_hits;
    }
@@ -395,6 +495,14 @@ namespace hddm_s_merger {
       tpol_integration_window_ns = dt_ns;
    }
  
+   bool get_fmwpc_merging() {
+      return enable_fmwpc_merging;
+   }
+   
+   void set_fmwpc_merging(bool merging_status) {
+      enable_fmwpc_merging = merging_status;
+   }
+
    int get_fmwpc_max_hits() {
       return fmwpc_max_hits;
    }
@@ -433,18 +541,18 @@ hddm_s::HitViewList &operator+=(hddm_s::HitViewList &dst,
       dst.add(1);
    hddm_s::HitViewList::iterator iter;
    for (iter = src.begin(); iter != src.end(); ++iter) {
-      dst(0).getCentralDCs() += iter->getCentralDCs();
-      dst(0).getForwardDCs() += iter->getForwardDCs();
-      dst(0).getStartCntrs() += iter->getStartCntrs();
-      dst(0).getBarrelEMcals() += iter->getBarrelEMcals();
-      dst(0).getForwardEMcals() += iter->getForwardEMcals();
-      dst(0).getForwardTOFs() += iter->getForwardTOFs();
-      dst(0).getComptonEMcals() += iter->getComptonEMcals();
-      dst(0).getTaggers() += iter->getTaggers();
-      dst(0).getPairSpectrometerFines() += iter->getPairSpectrometerFines();
-      dst(0).getPairSpectrometerCoarses() += iter->getPairSpectrometerCoarses();
-      dst(0).getTripletPolarimeters() += iter->getTripletPolarimeters();
-      dst(0).getForwardMWPCs() += iter->getForwardMWPCs();
+      if(enable_cdc_merging) dst(0).getCentralDCs() += iter->getCentralDCs();
+      if(enable_fdc_merging) dst(0).getForwardDCs() += iter->getForwardDCs();
+      if(enable_stc_merging) dst(0).getStartCntrs() += iter->getStartCntrs();
+      if(enable_bcal_merging) dst(0).getBarrelEMcals() += iter->getBarrelEMcals();
+      if(enable_fcal_merging) dst(0).getForwardEMcals() += iter->getForwardEMcals();
+      if(enable_ftof_merging) dst(0).getForwardTOFs() += iter->getForwardTOFs();
+      if(enable_ccal_merging) dst(0).getComptonEMcals() += iter->getComptonEMcals();
+      if(enable_tag_merging) dst(0).getTaggers() += iter->getTaggers();
+      if(enable_ps_merging) dst(0).getPairSpectrometerFines() += iter->getPairSpectrometerFines();
+      if(enable_psc_merging) dst(0).getPairSpectrometerCoarses() += iter->getPairSpectrometerCoarses();
+      if(enable_tpol_merging) dst(0).getTripletPolarimeters() += iter->getTripletPolarimeters();
+      if(enable_fmwpc_merging) dst(0).getForwardMWPCs() += iter->getForwardMWPCs();
    }
    return dst;
 }

--- a/src/programs/Simulation/mcsmear/hddm_s_merger.h
+++ b/src/programs/Simulation/mcsmear/hddm_s_merger.h
@@ -14,12 +14,16 @@ namespace hddm_s_merger {
    void set_t_shift_ns(double dt_ns);
 
    // hits merging / truncation parameters for the CDC
+   bool get_cdc_merging();
+   void set_cdc_merging(bool merging_status);
    int get_cdc_max_hits();
    void set_cdc_max_hits(int maxhits);
    double get_cdc_integration_window_ns();
    void set_cdc_integration_window_ns(double dt_ns);
 
    // hits merging / truncation parameters for the FDC
+   bool get_fdc_merging();
+   void set_fdc_merging(bool merging_status);
    int get_fdc_wires_max_hits();
    void set_fdc_wires_max_hits(int maxhits);
    double get_fdc_wires_min_delta_t_ns();
@@ -30,6 +34,8 @@ namespace hddm_s_merger {
    void set_fdc_strips_integration_window_ns(double dt_ns);
 
    // hits merging / truncation parameters for the STC
+   bool get_stc_merging();
+   void set_stc_merging(bool merging_status);
    int get_stc_adc_max_hits();
    void set_stc_adc_max_hits(int maxhits);
    int get_stc_tdc_max_hits();
@@ -40,6 +46,8 @@ namespace hddm_s_merger {
    void set_stc_integration_window_ns(double dt_ns);
 
    // hits merging / truncation parameters for the BCAL
+   bool get_bcal_merging();
+   void set_bcal_merging(bool merging_status);
    int get_bcal_adc_max_hits();
    void set_bcal_adc_max_hits(int maxhits);
    int get_bcal_tdc_max_hits();
@@ -54,6 +62,8 @@ namespace hddm_s_merger {
    void set_bcal_tdc_counts_per_ns(double slope);
 
    // hits merging / truncation parameters for the TOF
+   bool get_ftof_merging();
+   void set_ftof_merging(bool merging_status);
    int get_ftof_adc_max_hits();
    void set_ftof_adc_max_hits(int maxhits);
    int get_ftof_tdc_max_hits();
@@ -64,6 +74,8 @@ namespace hddm_s_merger {
    void set_ftof_integration_window_ns(double dt_ns);
 
    // hits merging / truncation parameters for the FCAL
+   bool get_fcal_merging();
+   void set_fcal_merging(bool merging_status);
    int get_fcal_max_hits();
    void set_fcal_max_hits(int maxhits);
    double get_fcal_min_delta_t_ns();
@@ -72,6 +84,8 @@ namespace hddm_s_merger {
    void set_fcal_integration_window_ns(double dt_ns);
 
    // hits merging / truncation parameters for the CCAL
+   bool get_ccal_merging();
+   void set_ccal_merging(bool merging_status);
    int get_ccal_max_hits();
    void set_ccal_max_hits(int maxhits);
    double get_ccal_min_delta_t_ns();
@@ -80,10 +94,15 @@ namespace hddm_s_merger {
    void set_ccal_integration_window_ns(double dt_ns);
 
    // hits merging / truncation parameters for the PS
+   bool get_ps_merging();
+   void set_ps_merging(bool merging_status);
    int get_ps_max_hits();
    void set_ps_max_hits(int maxhits);
    double get_ps_integration_window_ns();
    void set_ps_integration_window_ns(double dt_ns);
+
+   bool get_psc_merging();
+   void set_psc_merging(bool merging_status);
    int get_psc_adc_max_hits();
    void set_psc_adc_max_hits(int maxhits);
    int get_psc_tdc_max_hits();
@@ -94,6 +113,8 @@ namespace hddm_s_merger {
    void set_psc_integration_window_ns(double dt_ns);
 
    // hits merging / truncation parameters for the TAGM/TAGH
+   bool get_tag_merging();
+   void set_tag_merging(bool merging_status);
    int get_tag_adc_max_hits();
    void set_tag_adc_max_hits(int maxhits);
    int get_tag_tdc_max_hits();
@@ -104,12 +125,16 @@ namespace hddm_s_merger {
    void set_tag_integration_window_ns(double dt_ns);
 
    // hits merging / truncation parameters for the TPOL
+   bool get_tpol_merging();
+   void set_tpol_merging(bool merging_status);
    int get_tpol_max_hits();
    void set_tpol_max_hits(int maxhits);
    double get_tpol_integration_window_ns();
    void set_tpol_integration_window_ns(double dt_ns);
  
    // hits merging / truncation parameters for the FWMPC
+   bool get_fmwpc_merging();
+   void set_fmwpc_merging(bool merging_status);
    int get_fmwpc_max_hits();
    void set_fmwpc_max_hits(int maxhits);
    double get_fmwpc_min_delta_t_ns();

--- a/src/programs/Simulation/mcsmear/mcsmear.cc
+++ b/src/programs/Simulation/mcsmear/mcsmear.cc
@@ -22,6 +22,7 @@ using namespace std;
 #include "MyProcessor.h"
 #include "JFactoryGenerator_ThreadCancelHandler.h"
 #include "mcsmear_config.h" 
+#include "hddm_s_merger.h"
 
 #include "units.h"
 #include "HDDM/hddm_s.hpp"
@@ -104,12 +105,13 @@ void ParseCommandLineArguments(int narg, char* argv[], mcsmear_config_t *config)
           case 'e': config->APPLY_EFFICIENCY_CORRECTIONS=false;  break;
           case 'm': config->APPLY_HITS_TRUNCATION=false;         break;
           case 'E': config->FCAL_ADD_LIGHTGUIDE_HITS=true;       break;
-	  case 'R': config->SKIP_READING_RCDB=true;              break;
-	 case 'l': {
-	   config->DETECTORS_TO_LOAD=&ptr[2];
-	   cout << "Detector list: " << config->DETECTORS_TO_LOAD << endl;  
-	   break;
-	 }
+	      case 'R': config->SKIP_READING_RCDB=true;              break;
+	      case 't': config->MERGE_TAGGER_HITS=false;             break;
+	      case 'l': {
+	   		config->DETECTORS_TO_LOAD=&ptr[2];
+	   		cout << "Detector list: " << config->DETECTORS_TO_LOAD << endl;  
+	   		break;
+	 	  }
           // BCAL parameters
           case 'G': config->BCAL_NO_T_SMEAR = true;              break;
           case 'H': config->BCAL_NO_DARK_PULSES = true;          break;
@@ -223,6 +225,7 @@ void Usage(void)
  //  cout << "    -Vthresh BCAL ADC threshold (def. " << BCAL_ADC_THRESHOLD_MEV << " MeV)" << endl;
  //  cout << "    -Xsigma  BCAL fADC time resolution (def. " << BCAL_FADC_TIME_RESOLUTION << " ns)" << endl;
    cout << "    -R       Don't load information from RCDB" << endl;
+   cout << "    -t       Don't merge random hits from tagger counters" << endl;
    cout << "    -D       Dump configuration debug information" << endl;
    cout << "    -G       Don't smear BCAL times (def. smear)" << endl;
    cout << "    -H       Don't add BCAL dark hits (def. add)" << endl;

--- a/src/programs/Simulation/mcsmear/mcsmear_config.cc
+++ b/src/programs/Simulation/mcsmear/mcsmear_config.cc
@@ -28,6 +28,7 @@ mcsmear_config_t::mcsmear_config_t()
 	APPLY_HITS_TRUNCATION  = true;
 	FCAL_ADD_LIGHTGUIDE_HITS = false;
 	SKIP_READING_RCDB = false;
+	MERGE_TAGGER_HITS = true;
 
           BCAL_NO_T_SMEAR = false;             
           BCAL_NO_DARK_PULSES = false;        

--- a/src/programs/Simulation/mcsmear/mcsmear_config.h
+++ b/src/programs/Simulation/mcsmear/mcsmear_config.h
@@ -36,6 +36,7 @@ class mcsmear_config_t
 	bool SMEAR_HITS;
 	bool DUMP_RCDB_CONFIG;
 	bool SKIP_READING_RCDB;
+	bool MERGE_TAGGER_HITS;
 
 	//bool SMEAR_BCAL;
 	//bool FDC_ELOSS_OFF;


### PR DESCRIPTION
If you use the -t switch when adding in random trigger backgrounds, the hits in the tagger will be ignored and not merged, so only the thrown beam photon is left.
This is useful for some fit studies.

Almost forgot to merge this?