### PR TITLE
remove include of complex.h

### DIFF
--- a/src/libraries/AMPTOOLS_AMPS/TwoPiAngles_primakoff.cc
+++ b/src/libraries/AMPTOOLS_AMPS/TwoPiAngles_primakoff.cc
@@ -4,7 +4,6 @@
 #include <string>
 #include <sstream>
 #include <cstdlib>
-#include <complex.h>
 
 #include "TLorentzVector.h"
 #include "TLorentzRotation.h"


### PR DESCRIPTION
There is some kind of conflict with the system complex.h and root versions greater than or equal to 6.13.08. Code compiles without explicit mention of complex.h.