### PR TITLE
* protect the inline geometry builder against extra geometry

### DIFF
--- a/src/programs/Simulation/HDGeant/dl_routines.cc
+++ b/src/programs/Simulation/HDGeant/dl_routines.cc
@@ -170,9 +170,11 @@ void init_runtime_xml_(void)
                 cout << *xiter << endl;
                 vector<map<string, string> > vals;
                 jcalib->GetCalib(*xiter, vals);
-                string &xml = vals[0].begin()->second;
-                ofstream xmlout(tempdir + xiter->substr(xiter->find("/")));
-                xmlout << xml;
+                for (unsigned int ix = 0; ix < vals.size(); ++ix) {
+                    string &xml = vals[ix].begin()->second;
+                    ofstream xmlout(tempdir + xiter->substr(xiter->find("/")));
+                    xmlout << xml;
+                }
             }
         }
         HDDS_XML = tempdir + "/main_HDDS.xml";


### PR DESCRIPTION
  in the ccdb GEOMETRY directory that is not defined for this
  run and variation [rtj]