### PR TITLE
Nsj extend 3 3mm

### DIFF
--- a/src/programs/Simulation/mcsmear/CDCSmearer.cc
+++ b/src/programs/Simulation/mcsmear/CDCSmearer.cc
@@ -220,26 +220,26 @@ void CDCSmearer::SmearEvent(hddm_s::HDDM *record)
 
           // try matching a second line segment to the first at dmax, descending to 0 at dmax+extra
           double extra = 0.33;  //cm
+          double refdmax = 0.65;  // dmax for reference run
 
           if (d > dmin) {
 
-	      if (d <= dmax) {
+	      if (d <= refdmax) {
 		  reference = refp0 + d*refp1;
-                  this_run = thisp0 + d*thisp1;
-
               } else {
-
-  		  double newp1 = -1*(refp0 + dmax*refp1)/extra;
-                  double newp0 =  -1*(dmax+extra)*newp1;
-
+    		  double newp1 = -1*(refp0 + refdmax*refp1)/extra;
+                  double newp0 =  -1*(refdmax+extra)*newp1;
                   reference = newp0 + d*newp1;
+              }
 
-  		  newp1 = -1*(thisp0 + dmax*thisp1)/extra;
-                  newp0 =  -1*(dmax+extra)*newp1;
-
+	      if (d <= dmax) {
+                  this_run = thisp0 + d*thisp1;
+              } else {
+  		  double newp1 = -1*(thisp0 + dmax*thisp1)/extra;
+                  double newp0 =  -1*(dmax+extra)*newp1;
                   this_run = newp0 + d*newp1;
-
 	      }
+
               amplitude = amplitude * this_run/reference;   
           }  
 

--- a/src/programs/Simulation/mcsmear/CDCSmearer.cc
+++ b/src/programs/Simulation/mcsmear/CDCSmearer.cc
@@ -213,13 +213,13 @@ void CDCSmearer::SmearEvent(hddm_s::HDDM *record)
 
         if (suppress_gain) { 
 
+          // apply correction for pulse amplitude.  Convert from charge to amplitude later on, after adding pedestal charge smearing 
+
           double reference;
           double this_run;
 
           // try matching a second line segment to the first at dmax, descending to 0 at dmax+extra
           double extra = 0.33;  //cm
-
-          // apply correction for pulse amplitude.  Convert from charge to amplitude later on, after adding pedestal charge smearing 
 
           if (d > dmin) {
 

--- a/src/programs/Simulation/mcsmear/CDCSmearer.cc
+++ b/src/programs/Simulation/mcsmear/CDCSmearer.cc
@@ -216,6 +216,9 @@ void CDCSmearer::SmearEvent(hddm_s::HDDM *record)
           double reference;
           double this_run;
 
+          // try matching a second line segment to the first at dmax, descending to 0 at dmax+extra
+          double extra = 0.33;  //cm
+
           // apply correction for pulse amplitude.  Convert from charge to amplitude later on, after adding pedestal charge smearing 
 
           if (d > dmin) {
@@ -226,13 +229,13 @@ void CDCSmearer::SmearEvent(hddm_s::HDDM *record)
 
               } else {
 
-  		  double newp1 = -1*(refp0 + dmax*refp1)/0.35;
-                  double newp0 =  -1*(dmax+0.35)*newp1;
+  		  double newp1 = -1*(refp0 + dmax*refp1)/extra;
+                  double newp0 =  -1*(dmax+extra)*newp1;
 
                   reference = newp0 + d*newp1;
 
-  		  newp1 = -1*(thisp0 + dmax*thisp1)/0.35;
-                  newp0 =  -1*(dmax+0.35)*newp1;
+  		  newp1 = -1*(thisp0 + dmax*thisp1)/extra;
+                  newp0 =  -1*(dmax+extra)*newp1;
 
                   this_run = newp0 + d*newp1;
 

--- a/src/programs/Simulation/mcsmear/CDCSmearer.h
+++ b/src/programs/Simulation/mcsmear/CDCSmearer.h
@@ -20,6 +20,7 @@ class cdc_config_t
 	double CDC_DIFFUSION_PAR1,CDC_DIFFUSION_PAR2,CDC_DIFFUSION_PAR3;
 
         vector<double> CDC_GAIN_DOCA_PARS;  // params to model gas deterioration spring 2018
+        vector<double> CDC_GAIN_DOCA_EXT;  // params to model gas deterioration spring 2018
 
 	vector< vector<double> > wire_efficiencies;
 	vector< vector<double> > wire_thresholds;


### PR DESCRIPTION
This is used by the CDC's gain vs DOCA correction code for spring 2018.  It adds a 3rd line segment to the model of CDC pulse height with DOCA, starting at the max DOCA used for dE/dx.  This gives better agreement with observed hit efficiency.  No change is necessary in the reconstruction code.  The last edit moved the extra line segment parameters into ccdb