### PR TITLE
Beam properties cleanup

### DIFF
--- a/src/libraries/UTILITIES/BeamProperties.cc
+++ b/src/libraries/UTILITIES/BeamProperties.cc
@@ -313,13 +313,17 @@ void BeamProperties::fillFluxFromCCDB() {
 
 	cout<<endl<<"BeamProperties: Using flux from CCDB run "<<mRunNumber<<endl;
 
-	// Parse to get run number
+	// Parse environment variables for CCDB setup
 	string ccdb_home(getenv("JANA_CALIB_URL"));
-	string variation(getenv("JANA_CALIB_CONTEXT"));
-	//cout<<ccdb_home.data()<<" "<<variation.data()<<endl;
+	string variation = "default";
+	const char *var_env = getenv("JANA_CALIB_CONTEXT");
+	if(var_env) { // use non-default context if provided 
+		variation = string(var_env);
+		cout<<"Using CCDB variation = "<<variation.data()<<endl;
+	}
 	
 	// Generate calibration class
-	auto_ptr<ccdb::Calibration> calib(ccdb::CalibrationGenerator::CreateCalibration(ccdb_home, mRunNumber)); //, variation));
+	auto_ptr<ccdb::Calibration> calib(ccdb::CalibrationGenerator::CreateCalibration(ccdb_home, mRunNumber, variation));
 	
 	// Get PS acceptance from CCDB
 	vector< vector<double> > psAccept;

--- a/src/libraries/UTILITIES/BeamProperties.cc
+++ b/src/libraries/UTILITIES/BeamProperties.cc
@@ -314,10 +314,8 @@ void BeamProperties::fillFluxFromCCDB() {
 	cout<<endl<<"BeamProperties: Using flux from CCDB run "<<mRunNumber<<endl;
 
 	// Parse environment variables for CCDB setup
-	string calib_url = "";
-	const char *calib_url_env = getenv("JANA_CALIB_URL");
-	if(calib_url_env) calib_url = string(calib_url_env);
-	else {
+	const char *calib_url = getenv("JANA_CALIB_URL");
+	if(!calib_url) {
 		cout<<"Can't compute flux with undefined JANA_CALIB_URL environment variable"<<endl;
 		exit(101);
 	}
@@ -330,7 +328,7 @@ void BeamProperties::fillFluxFromCCDB() {
 	}
 	
 	// Generate calibration class
-	auto_ptr<ccdb::Calibration> calib(ccdb::CalibrationGenerator::CreateCalibration(calib_url, mRunNumber, variation));
+	auto_ptr<ccdb::Calibration> calib(ccdb::CalibrationGenerator::CreateCalibration(string(calib_url), mRunNumber, variation));
 	
 	// Get PS acceptance from CCDB
 	vector< vector<double> > psAccept;

--- a/src/libraries/UTILITIES/BeamProperties.cc
+++ b/src/libraries/UTILITIES/BeamProperties.cc
@@ -314,16 +314,23 @@ void BeamProperties::fillFluxFromCCDB() {
 	cout<<endl<<"BeamProperties: Using flux from CCDB run "<<mRunNumber<<endl;
 
 	// Parse environment variables for CCDB setup
-	string ccdb_home(getenv("JANA_CALIB_URL"));
+	string calib_url = "";
+	const char *calib_url_env = getenv("JANA_CALIB_URL");
+	if(calib_url_env) calib_url = string(calib_url_env);
+	else {
+		cout<<"Can't compute flux with undefined JANA_CALIB_URL environment variable"<<endl;
+		exit(101);
+	}
+
 	string variation = "default";
-	const char *var_env = getenv("JANA_CALIB_CONTEXT");
-	if(var_env) { // use non-default context if provided 
-		variation = string(var_env);
+	const char *variation_env = getenv("JANA_CALIB_CONTEXT");
+	if(variation_env) { // use non-default context if provided 
+		variation = string(variation_env);
 		cout<<"Using CCDB variation = "<<variation.data()<<endl;
 	}
 	
 	// Generate calibration class
-	auto_ptr<ccdb::Calibration> calib(ccdb::CalibrationGenerator::CreateCalibration(ccdb_home, mRunNumber, variation));
+	auto_ptr<ccdb::Calibration> calib(ccdb::CalibrationGenerator::CreateCalibration(calib_url, mRunNumber, variation));
 	
 	// Get PS acceptance from CCDB
 	vector< vector<double> > psAccept;


### PR DESCRIPTION
Addresses issue #199 to use default variation if JANA_CALIB_CONTEXT is not set and also checks that JANA_CALIB_URL (which is required) is set.  If a non-existent variation is provided, the CCDB error message for an invalid variation is reported when the error is thrown.