### PR TITLE
Change default (value used when SQLITECPP_VERSION is undefined) of sq…

### DIFF
--- a/src/SBMS/sbms.py
+++ b/src/SBMS/sbms.py
@@ -688,7 +688,7 @@ def AddSQLite(env):
 	SQLITECPP_CPPPATH = ["%s/include" % (sqlitecpp_home)]
 	env.AppendUnique(CPPPATH = SQLITECPP_CPPPATH)
 	sqlitecpp_ge_2_5 = version_greater_than_or_equal_to('SQLITECPP_VERSION', [2, 5, 0])
-	if not sqlitecpp_ge_2_5.defined or sqlitecpp_ge_2_5.answer:
+	if sqlitecpp_ge_2_5.defined and sqlitecpp_ge_2_5.answer:
 		SQLITECPP_LIBPATH = ["%s/lib64" % (sqlitecpp_home)]
 	else:
 		SQLITECPP_LIBPATH = ["%s/lib" % (sqlitecpp_home)]


### PR DESCRIPTION
…litecpp lib directory to old name (lib) rather than new (lib64).
Also change sqlitecpp CPP option depending on version of sqlite.