### PR TITLE
randomized fit starting parameters

### DIFF
--- a/src/libraries/AMPTOOLS_AMPS/omegapiAngles.cc
+++ b/src/libraries/AMPTOOLS_AMPS/omegapiAngles.cc
@@ -114,9 +114,9 @@ vector <double> getomegapiAngles(double polAngle, TLorentzVector daughter, TLore
   double theta = Angles.Theta();
   double phi = Angles.Phi();
 
-  //TVector3 eps(cos(polAngle*TMath::DegToRad()), sin(polAngle*TMath::DegToRad()), 0.0); // beam polarization vector
-  //double Phi = atan2(y.Dot(eps), InverseOfX.Vect().Unit().Dot(eps.Cross(y)));
-  double Phi = z.Phi();
+  // set beam polarization angle to 0 degrees; apply diamond orientation in calcAmplitude
+  TVector3 eps(1.0, 0.0, 0.0); 
+  double Phi = atan2(y.Dot(eps), InverseOfX.Vect().Unit().Dot(eps.Cross(y)));
 
   vector <double> thetaphiPhi{theta, phi, Phi};
     

--- a/src/programs/AmplitudeAnalysis/fit/fit.cc
+++ b/src/programs/AmplitudeAnalysis/fit/fit.cc
@@ -85,7 +85,7 @@ double runSingleFit(ConfigurationInfo* cfgInfo, bool useMinos, int maxIter, stri
    return ati.likelihood();
 }
 
-void runRndFits(ConfigurationInfo* cfgInfo, bool useMinos, int maxIter, int numRnd, double maxFraction) {
+void runRndFits(ConfigurationInfo* cfgInfo, bool useMinos, int maxIter, string seedfile, int numRnd, double maxFraction) {
    AmpToolsInterface ati( cfgInfo );
    string fitName = cfgInfo->fitName();
 
@@ -125,6 +125,11 @@ void runRndFits(ConfigurationInfo* cfgInfo, bool useMinos, int maxIter, int numR
 
      ati.finalizeFit(to_string(i));
 
+     if( seedfile.size() != 0 && !fitFailed ){
+	string seedfile_rand = seedfile + Form("_%d.txt", i);
+	ati.fitResults()->writeSeed( seedfile_rand );
+     }
+
      // update best fit
      if( !fitFailed && ati.likelihood() < minLL ) {
         minLL = ati.likelihood();
@@ -137,6 +142,8 @@ void runRndFits(ConfigurationInfo* cfgInfo, bool useMinos, int maxIter, int numR
     else {
       cout << "MINIMUM LIKELIHOOD FROM " << minFitTag << " of " << numRnd << " RANDOM PRODUCTION PARS = " << minLL << endl;
       gSystem->Exec(Form("cp %s_%d.fit %s.fit", fitName.data(), minFitTag, fitName.data()));
+      if( seedfile.size() != 0 )
+	      gSystem->Exec(Form("cp %s_%d.txt %s.txt", seedfile.data(), minFitTag, seedfile.data()));
    }
 }
 
@@ -219,7 +226,7 @@ int main( int argc, char* argv[] ){
    if(numRnd==0){
      runSingleFit(cfgInfo, useMinos, maxIter, seedfile);
    } else {
-     runRndFits(cfgInfo, useMinos, maxIter, numRnd, 0.5);
+     runRndFits(cfgInfo, useMinos, maxIter, seedfile, numRnd, 0.5);
    }
 
    return 0;

--- a/src/programs/AmplitudeAnalysis/fit/fit.cc
+++ b/src/programs/AmplitudeAnalysis/fit/fit.cc
@@ -8,6 +8,8 @@
 #include <utility>
 #include <map>
 
+#include "TSystem.h"
+
 #include "AMPTOOLS_DATAIO/ROOTDataReader.h"
 #include "AMPTOOLS_DATAIO/ROOTDataReaderBootstrap.h"
 #include "AMPTOOLS_DATAIO/ROOTDataReaderWithTCut.h"


### PR DESCRIPTION
Randomized starting parameters for fits have been used for a while now, but not in the master branch.  The -r option allows the user to specify the number of random starting values on the command line and if this option isn't supplied, only a single fit is performed.  Some rough documentation on usage is here https://halldweb.jlab.org/wiki-private/index.php/Randomized_fit_starting_parameters