### PR TITLE
Zlm updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ Simulation for GlueX.
 See the [Offline Software Wiki Page](https://halldweb.jlab.org/wiki/index.php/GlueX_Offline_Software#Software_Packages) for more information.
 
 Contains programs used to do detector simulation and event generation.
+

--- a/src/libraries/AMPTOOLS_AMPS/Zlm.cc
+++ b/src/libraries/AMPTOOLS_AMPS/Zlm.cc
@@ -16,25 +16,36 @@
 Zlm::Zlm( const vector< string >& args ) :
    UserAmplitude< Zlm >( args )
 {
-   assert( args.size() == 6 || args.size() == 7 );
+   assert( args.size() == 4 || args.size() == 6 || args.size() == 8 );
 
    m_j = atoi( args[0].c_str() );
    m_m = atoi( args[1].c_str() );
    m_r = atoi( args[2].c_str() );
    m_s = atoi( args[3].c_str() );
 
-   if(args.size() == 6) {
+   // Three possibilities to initialize this amplitude:
+   // (with <J>: total spin, <m>: spin projection, <r>: +1/-1 for real/imaginary part; <s>: +1/-1 sign in P_gamma term)
+   //
+   // 1: four arguments, polarization information must be included in beam photon four vector
+   //    Usage: amplitude <reaction>::<sum>::<ampName> Zlm <J> <m> <r> <s>
+   if(args.size() == 4) {
+      m_polInTree = true;
+   
+   // 2: six arguments, polarization fixed per amplitude and passed as flag
+   //    Usage: amplitude <reaction>::<sum>::<ampName> Zlm <J> <m> <r> <s> <polAngle> <polFraction>
+   } else if(args.size() == 6) {
       m_polInTree = false;
       m_polAngle = atof( args[4].c_str() );
       m_polFraction = atof( args[5].c_str() );
-
-      if( m_polFraction == 0 ){
-         TFile* f = new TFile( args[5].c_str() );
-         m_polFrac_vs_E = (TH1D*)f->Get( args[6].c_str() );
-         assert( m_polFrac_vs_E != NULL );
-      }
-   }else if(args.size() == 4)
-      m_polInTree = true;
+   
+   // 3: eight arguments, read polarization from histogram <hist> in file <rootFile>
+   //    Usage: amplitude <reaction>::<sum>::<ampName> Zlm <J> <m> <r> <s> 0. <polFraction> <rootFile> <hist>
+   } else if(args.size() == 8) {
+      m_polInTree = false;
+      TFile* f = new TFile( args[6].c_str() );
+      m_polFrac_vs_E = (TH1D*)f->Get( args[7].c_str() );
+      assert( m_polFrac_vs_E != NULL );
+   }
 
    // make sure values are reasonable
    assert( abs( m_m ) <= m_j );

--- a/src/libraries/AMPTOOLS_AMPS/Zlm.cc
+++ b/src/libraries/AMPTOOLS_AMPS/Zlm.cc
@@ -1,4 +1,3 @@
-
 #include <cassert>
 #include <iostream>
 #include <string>
@@ -15,110 +14,125 @@
 #include "TFile.h"
 
 Zlm::Zlm( const vector< string >& args ) :
-UserAmplitude< Zlm >( args )
+   UserAmplitude< Zlm >( args )
 {
-  assert( args.size() == 6 || args.size() == 7 );
-  
-  m_j = atoi( args[0].c_str() );
-  m_m = atoi( args[1].c_str() );
-  m_r = atoi( args[2].c_str() );
-  m_s = atoi( args[3].c_str() );
+   assert( args.size() == 6 || args.size() == 7 );
 
-  m_polAngle = atof( args[4].c_str() );
-  m_polFraction = atof( args[5].c_str() );
-  
-  if( m_polFraction == 0 ){
-    
-    TFile* f = new TFile( args[5].c_str() );
-    m_polFrac_vs_E = (TH1D*)f->Get( args[6].c_str() );
-    assert( m_polFrac_vs_E != NULL );
-  }
-  
-  // make sure values are reasonable
-  assert( abs( m_m ) <= m_j );
-  // m_r = +1 for real
-  // m_r = -1 for imag
-  assert( abs( m_r ) == 1 );
-  // m_s = +1 for 1 + Pgamma
-  // m_s = -1 for 1 - Pgamma
-  assert( abs( m_s ) == 1 );
+   m_j = atoi( args[0].c_str() );
+   m_m = atoi( args[1].c_str() );
+   m_r = atoi( args[2].c_str() );
+   m_s = atoi( args[3].c_str() );
+
+   if(args.size() == 6) {
+      m_polInTree = false;
+      m_polAngle = atof( args[4].c_str() );
+      m_polFraction = atof( args[5].c_str() );
+
+      if( m_polFraction == 0 ){
+         TFile* f = new TFile( args[5].c_str() );
+         m_polFrac_vs_E = (TH1D*)f->Get( args[6].c_str() );
+         assert( m_polFrac_vs_E != NULL );
+      }
+   }else if(args.size() == 4)
+      m_polInTree = true;
+
+   // make sure values are reasonable
+   assert( abs( m_m ) <= m_j );
+   // m_r = +1 for real
+   // m_r = -1 for imag
+   assert( abs( m_r ) == 1 );
+   // m_s = +1 for 1 + Pgamma
+   // m_s = -1 for 1 - Pgamma
+   assert( abs( m_s ) == 1 );
 }
 
 
 complex< GDouble >
 Zlm::calcAmplitude( GDouble** pKin, GDouble* userVars ) const {
 
-  GDouble pGamma = userVars[kPgamma];
-  GDouble cosTheta = userVars[kCosTheta];
-  GDouble phi = userVars[kPhi];
-  GDouble bigPhi = userVars[kBigPhi];
-  
-  GDouble factor = sqrt(1 + m_s * pGamma);
-  GDouble zlm = 0;
-  complex< GDouble > rotateY = polar(1., -1.*bigPhi);
-  if (m_r == 1)
-    zlm = real(Y( m_j, m_m, cosTheta, phi ) * rotateY);
-  if (m_r == -1)
-    zlm = imag(Y( m_j, m_m, cosTheta, phi ) * rotateY);
+   GDouble pGamma = userVars[kPgamma];
+   GDouble cosTheta = userVars[kCosTheta];
+   GDouble phi = userVars[kPhi];
+   GDouble bigPhi = userVars[kBigPhi];
 
-  return complex< GDouble >( factor * zlm );
+   GDouble factor = sqrt(1 + m_s * pGamma);
+   GDouble zlm = 0;
+   complex< GDouble > rotateY = polar(1., -1.*bigPhi);
+   if (m_r == 1)
+      zlm = real(Y( m_j, m_m, cosTheta, phi ) * rotateY);
+   if (m_r == -1)
+      zlm = imag(Y( m_j, m_m, cosTheta, phi ) * rotateY);
+
+   return complex< GDouble >( factor * zlm );
 }
 
 void
 Zlm::calcUserVars( GDouble** pKin, GDouble* userVars ) const {
-  
-  TLorentzVector beam   ( pKin[0][1], pKin[0][2], pKin[0][3], pKin[0][0] ); 
-  TLorentzVector recoil ( pKin[1][1], pKin[1][2], pKin[1][3], pKin[1][0] ); 
-  TLorentzVector p1     ( pKin[2][1], pKin[2][2], pKin[2][3], pKin[2][0] ); 
-  TLorentzVector p2     ( pKin[3][1], pKin[3][2], pKin[3][3], pKin[3][0] ); 
-  
-  TLorentzVector resonance = p1 + p2;
-  
-  TLorentzRotation resRestBoost( -resonance.BoostVector() );
-  
-  TLorentzVector beam_res   = resRestBoost * beam;
-  TLorentzVector recoil_res = resRestBoost * recoil;
-  TLorentzVector p1_res = resRestBoost * p1;
-  
-  // Helicity frame
-  TVector3 z = -1. * recoil_res.Vect().Unit();
-  // or GJ frame?
-  // TVector3 z = beam_res.Vect().Unit();
+   TLorentzVector beam;
+   TVector3 eps;
 
-  // normal to the production plane
-  TVector3 y = (beam.Vect().Unit().Cross(-recoil.Vect().Unit())).Unit();
+   if(m_polInTree) {
+      beam.SetPxPyPzE( 0., 0., pKin[0][0], pKin[0][0]);
+      eps.SetXYZ(pKin[0][1], pKin[0][2], 0.); // makes default output gen_amp trees readable as well (without transforming)
+   } else {
+      beam.SetPxPyPzE( pKin[0][1], pKin[0][2], pKin[0][3], pKin[0][0] ); 
+      eps.SetXYZ(cos(m_polAngle*TMath::DegToRad()), sin(m_polAngle*TMath::DegToRad()), 0.0); // beam polarization vector
+   }
 
-  TVector3 x = y.Cross(z);
-  
-  TVector3 angles( (p1_res.Vect()).Dot(x),
-                   (p1_res.Vect()).Dot(y),
-                   (p1_res.Vect()).Dot(z) );
-  
-  userVars[kCosTheta] = angles.CosTheta();
-  userVars[kPhi] = angles.Phi();
+   TLorentzVector recoil ( pKin[1][1], pKin[1][2], pKin[1][3], pKin[1][0] ); 
+   TLorentzVector p1     ( pKin[2][1], pKin[2][2], pKin[2][3], pKin[2][0] ); 
+   TLorentzVector p2     ( pKin[3][1], pKin[3][2], pKin[3][3], pKin[3][0] ); 
 
-  TVector3 eps(cos(m_polAngle*TMath::DegToRad()), sin(m_polAngle*TMath::DegToRad()), 0.0); // beam polarization vector
-  userVars[kBigPhi] = atan2(y.Dot(eps), beam.Vect().Unit().Dot(eps.Cross(y)));
+   TLorentzVector resonance = p1 + p2;
 
-  GDouble pGamma;
-  if( m_polFraction > 0.) { // for fitting with constant polarization
-    pGamma = m_polFraction;
-  }
-  else{
-    int bin = m_polFrac_vs_E->GetXaxis()->FindBin(pKin[0][0]);
-    if (bin == 0 || bin > m_polFrac_vs_E->GetXaxis()->GetNbins()){
-      pGamma = 0.;
-    }
-    else pGamma = m_polFrac_vs_E->GetBinContent(bin);
-  }
-  
-  userVars[kPgamma] = pGamma;
+   TLorentzRotation resRestBoost( -resonance.BoostVector() );
+
+   TLorentzVector beam_res   = resRestBoost * beam;
+   TLorentzVector recoil_res = resRestBoost * recoil;
+   TLorentzVector p1_res = resRestBoost * p1;
+
+   // Helicity frame
+   TVector3 z = -1. * recoil_res.Vect().Unit();
+   // or GJ frame?
+   // TVector3 z = beam_res.Vect().Unit();
+
+   // normal to the production plane
+   TVector3 y = (beam.Vect().Unit().Cross(-recoil.Vect().Unit())).Unit();
+
+   TVector3 x = y.Cross(z);
+
+   TVector3 angles( (p1_res.Vect()).Dot(x),
+         (p1_res.Vect()).Dot(y),
+         (p1_res.Vect()).Dot(z) );
+
+   userVars[kCosTheta] = angles.CosTheta();
+   userVars[kPhi] = angles.Phi();
+
+   userVars[kBigPhi] = atan2(y.Dot(eps), beam.Vect().Unit().Dot(eps.Cross(y)));
+
+
+   GDouble pGamma;
+   if(m_polInTree) {
+      pGamma = eps.Mag();
+   } else {
+      if(m_polFraction > 0.) { // for fitting with constant polarization 
+         pGamma = m_polFraction;
+      } else{
+         int bin = m_polFrac_vs_E->GetXaxis()->FindBin(pKin[0][0]);
+         if (bin == 0 || bin > m_polFrac_vs_E->GetXaxis()->GetNbins()){
+            pGamma = 0.;
+         } else 
+            pGamma = m_polFrac_vs_E->GetBinContent(bin);
+      }
+   }
+
+   userVars[kPgamma] = pGamma;
 }
 
 #ifdef GPU_ACCELERATION
 void
 Zlm::launchGPUKernel( dim3 dimGrid, dim3 dimBlock, GPU_AMP_PROTO ) const {
 
-  GPUZlm_exec( dimGrid, dimBlock, GPU_AMP_ARGS, m_j, m_m, m_r, m_s );
+   GPUZlm_exec( dimGrid, dimBlock, GPU_AMP_ARGS, m_j, m_m, m_r, m_s );
 }
 #endif

--- a/src/libraries/AMPTOOLS_AMPS/Zlm.h
+++ b/src/libraries/AMPTOOLS_AMPS/Zlm.h
@@ -11,6 +11,13 @@
 #include <complex>
 #include <vector>
 
+#ifdef GPU_ACCELERATION
+void
+GPUZlm_exec( dim3 dimGrid, dim3 dimBlock, GPU_AMP_PROTO,
+	     int j, int m, int r, int s );
+#endif // GPU_ACCELERATION
+
+
 using std::complex;
 using namespace std;
 
@@ -27,26 +34,45 @@ class Kinematics;
 class Zlm : public UserAmplitude< Zlm >
 {
     
-public:
+ public:
 	
-	Zlm() : UserAmplitude< Zlm >() { };
-	Zlm( const vector< string >& args );
+ Zlm() : UserAmplitude< Zlm >() { };
+  Zlm( const vector< string >& args );
 	
-	string name() const { return "Zlm"; }
+  enum UserVars { kPgamma = 0, kCosTheta, kPhi, kBigPhi, kNumUserVars };
+  unsigned int numUserVars() const { return kNumUserVars; }
+  
+  string name() const { return "Zlm"; }
     
-	complex< GDouble > calcAmplitude( GDouble** pKin ) const;
-	
-private:
+  complex< GDouble > calcAmplitude( GDouble** pKin, GDouble* userVars ) const;
+  void calcUserVars( GDouble** pKin, GDouble* userVars ) const;
+
+  // we can calcualte everything we need from userVars block so allow
+  // the framework to purge the four-vectors
+  bool needsUserVarsOnly() const { return true; }
+
+  // the user variables above are the same for all instances of this amplitude
+  bool areUserVarsStatic() const { return true; }
+
+#ifdef GPU_ACCELERATION
+  
+  void launchGPUKernel( dim3 dimGrid, dim3 dimBlock, GPU_AMP_PROTO ) const;
+  
+  bool isGPUEnabled() const { return true; }
+  
+#endif // GPU_ACCELERATION
+  
+ private:
         
   int m_j;
   int m_m;
   int m_r;
   int m_s;
 	
-  AmpParameter polAngle;
-
-  double polFraction;
-  TH1D *polFrac_vs_E;
+  double m_polAngle;
+  double m_polFraction;
+  
+  TH1D* m_polFrac_vs_E;
 };
 
 #endif

--- a/src/libraries/AMPTOOLS_AMPS/Zlm.h
+++ b/src/libraries/AMPTOOLS_AMPS/Zlm.h
@@ -14,7 +14,7 @@
 #ifdef GPU_ACCELERATION
 void
 GPUZlm_exec( dim3 dimGrid, dim3 dimBlock, GPU_AMP_PROTO,
-	     int j, int m, int r, int s );
+      int j, int m, int r, int s );
 #endif // GPU_ACCELERATION
 
 
@@ -33,46 +33,47 @@ class Kinematics;
 
 class Zlm : public UserAmplitude< Zlm >
 {
-    
- public:
-	
- Zlm() : UserAmplitude< Zlm >() { };
-  Zlm( const vector< string >& args );
-	
-  enum UserVars { kPgamma = 0, kCosTheta, kPhi, kBigPhi, kNumUserVars };
-  unsigned int numUserVars() const { return kNumUserVars; }
-  
-  string name() const { return "Zlm"; }
-    
-  complex< GDouble > calcAmplitude( GDouble** pKin, GDouble* userVars ) const;
-  void calcUserVars( GDouble** pKin, GDouble* userVars ) const;
 
-  // we can calcualte everything we need from userVars block so allow
-  // the framework to purge the four-vectors
-  bool needsUserVarsOnly() const { return true; }
+   public:
 
-  // the user variables above are the same for all instances of this amplitude
-  bool areUserVarsStatic() const { return true; }
+      Zlm() : UserAmplitude< Zlm >() { };
+      Zlm( const vector< string >& args );
+
+      enum UserVars { kPgamma = 0, kCosTheta, kPhi, kBigPhi, kNumUserVars };
+      unsigned int numUserVars() const { return kNumUserVars; }
+
+      string name() const { return "Zlm"; }
+
+      complex< GDouble > calcAmplitude( GDouble** pKin, GDouble* userVars ) const;
+      void calcUserVars( GDouble** pKin, GDouble* userVars ) const;
+
+      // we can calcualte everything we need from userVars block so allow
+      // the framework to purge the four-vectors
+      bool needsUserVarsOnly() const { return true; }
+
+      // the user variables above are the same for all instances of this amplitude
+      bool areUserVarsStatic() const { return true; }
 
 #ifdef GPU_ACCELERATION
-  
-  void launchGPUKernel( dim3 dimGrid, dim3 dimBlock, GPU_AMP_PROTO ) const;
-  
-  bool isGPUEnabled() const { return true; }
-  
+
+      void launchGPUKernel( dim3 dimGrid, dim3 dimBlock, GPU_AMP_PROTO ) const;
+
+      bool isGPUEnabled() const { return true; }
+
 #endif // GPU_ACCELERATION
-  
- private:
-        
-  int m_j;
-  int m_m;
-  int m_r;
-  int m_s;
-	
-  double m_polAngle;
-  double m_polFraction;
-  
-  TH1D* m_polFrac_vs_E;
+
+   private:
+
+      int m_j;
+      int m_m;
+      int m_r;
+      int m_s;
+
+      double m_polAngle;
+      double m_polFraction;
+      bool m_polInTree;
+
+      TH1D* m_polFrac_vs_E;
 };
 
 #endif

--- a/src/libraries/AMPTOOLS_AMPS/Zlm_kernel.cu
+++ b/src/libraries/AMPTOOLS_AMPS/Zlm_kernel.cu
@@ -1,0 +1,45 @@
+#include <stdio.h>
+
+#include "GPUManager/GPUCustomTypes.h"
+#include "GPUManager/CUDA-Complex.cuh"
+#include "GPUUtils/wignerD.cuh"
+
+__global__ void
+Zlm_kernel( GPU_AMP_PROTO, int j, int m, int r, int s ){
+
+  int iEvent = GPU_THIS_EVENT;
+
+  // here we need to be careful to index the user-defined
+  // data with the proper integer corresponding to the
+  // enumeration in the C++ header file
+
+  GDouble pGamma = GPU_UVARS(0);
+  GDouble cosTheta = GPU_UVARS(1);
+  GDouble phi = GPU_UVARS(2);
+  GDouble bigPhi = GPU_UVARS(3);
+
+  GDouble factor = sqrt(1 + s * pGamma);
+  GDouble zlm = 0;
+
+  WCUComplex rotateY = { G_COS( bigPhi ), -G_SIN( bigPhi ) };
+  if( r == 1 ){
+    zlm = ( Y( j, m, cosTheta, phi ) * rotateY ).Re();
+  }
+  if( r == -1 ){
+    zlm = ( Y( j, m, cosTheta, phi ) * rotateY ).Im();
+  }
+
+  WCUComplex amp = { factor * zlm, 0 };
+
+  pcDevAmp[iEvent] = amp;
+}
+
+
+void
+GPUZlm_exec( dim3 dimGrid, dim3 dimBlock, GPU_AMP_PROTO,
+              int j, int m, int r, int s  )
+{
+
+  Zlm_kernel<<< dimGrid, dimBlock >>>( GPU_AMP_ARGS, j, m, r, s );
+}
+


### PR DESCRIPTION
- Added GPU code for Zlm amplitude (by Matt)
- Added alternative options to initialize Zlm amplitude in cfg file to make use of polarization information in the AmpTools root trees

Changes are backwards compatible with "old" trees. 

There is a third option to use the Zlm amplitude, using a histogram of polarization vs. E. Usage of BeamProperties class is removed at the moment and replaced with reading from a plain root file. If we need it back, I can re-add that before merging into master. 