### PR TITLE
Fmwpc smear update

### DIFF
--- a/src/programs/Simulation/mcsmear/FMWPCSmearer.h
+++ b/src/programs/Simulation/mcsmear/FMWPCSmearer.h
@@ -8,13 +8,14 @@
 class fmwpc_config_t 
 {
   public:
-	fmwpc_config_t(JEventLoop *loop);
+  fmwpc_config_t(JEventLoop *loop);
+  
+  // FMWPC resolutions and threshold
+  double FMWPC_TSIGMA;
+  double FMWPC_ASIGMA;
+  double FMWPC_THRESHOLD;
 
-	// FMWPC resolutions and threshold
-	double FMWPC_TSIGMA;
-	double FMWPC_ASIGMA;
-	double FMWPC_THRESHOLD;
-
+  double FMWPC_INTEGRAL_TO_AMPLITUDE;
 };
 
 
@@ -38,3 +39,4 @@ class FMWPCSmearer : public Smearer
 
 
 #endif // _FMWPCSMEARER_H_
+

--- a/src/programs/Simulation/mcsmear/hddm_s_merger.cc
+++ b/src/programs/Simulation/mcsmear/hddm_s_merger.cc
@@ -1988,25 +1988,25 @@ hddm_s::FmwpcHitList &operator+=(hddm_s::FmwpcHitList &dst,
    for (iter = src.begin(); iter != src.end(); ++iter) {
       double t = iter->getT() + t_shift_ns;
       double dt = fmwpc_min_delta_t_ns;
-      double newDE = iter->getDE();
+      double newQ = iter->getQ();
       while (iord > 0 && dst(iord).getT() > t)
          --iord;
       while (iord < dst.size() && dst(iord).getT() < t)
          ++iord;
       if (iord > 0 && t - dst(iord - 1).getT() < dt) {
-         double oldDE = dst(iord - 1).getDE();
+         double oldQ = dst(iord - 1).getQ();
          double pulse_fraction = 1 - (t - dst(iord - 1).getT()) / dt;
-         dst(iord - 1).setDE(oldDE + newDE * pulse_fraction);
+         dst(iord - 1).setQ(oldQ + newQ * pulse_fraction);
       }
       else if (iord < dst.size() && dst(iord).getT() - t < dt) {
-         double oldDE = dst(iord).getDE();
+         double oldQ = dst(iord).getQ();
          double pulse_fraction = 1 - (dst(iord).getT() - t) / dt;
-         dst(iord).setDE(newDE + oldDE * pulse_fraction);
+         dst(iord).setQ(newQ + oldQ * pulse_fraction);
          dst(iord).setT(t);
       }
       else {
          dst.add(1, (iord < dst.size())? iord : -1);
-         dst(iord).setDE(newDE);
+         dst(iord).setQ(newQ);
          dst(iord).setT(t);
       }
    }


### PR DESCRIPTION
Update smearing for FMWPC hits to reflect change from dE to q in the hit class and to add simulation of the drift time and the longitudinal diffusion (which smears the time).