### PR TITLE
initialize random generator pointer in default constructor

### DIFF
--- a/src/libraries/AMPTOOLS_DATAIO/ROOTDataReaderBootstrap.h
+++ b/src/libraries/AMPTOOLS_DATAIO/ROOTDataReaderBootstrap.h
@@ -22,7 +22,10 @@ public:
   /**
    * Default constructor for ROOTDataReaderBootstrap
    */
-  ROOTDataReaderBootstrap() : UserDataReader< ROOTDataReaderBootstrap >(), m_inFile( NULL ) { }
+ ROOTDataReaderBootstrap() : 
+  UserDataReader< ROOTDataReaderBootstrap >(), 
+    m_inFile( NULL ), 
+    m_randGenerator( NULL ) { }
   
   ~ROOTDataReaderBootstrap();
   


### PR DESCRIPTION
This avoids a segfault in the destructor when the default constructor is invoked.  (The revisions to AmpTools to share data occasionally result in the default data reader constructor being invoked.)