### PR TITLE
bggen_upd: reac_eve.F one code line used for testing is commented out

### DIFF
--- a/src/programs/Simulation/bggen_upd/code/reac_eve.F
+++ b/src/programs/Simulation/bggen_upd/code/reac_eve.F
@@ -36,7 +36,7 @@ C
 C
 C     ------------------------------------------------------------------
 C
-      tslreac=1.2  ! !!!
+C      tslreac=1.2  ! test, commented out
       IERR=1
       NTRA=0
       IF(ISIMUL.LT.1.OR.ISIMUL.GT.1) GO TO 999


### PR DESCRIPTION
A bug fix - commenting out a line used for the code testing in the jpsi simulation section. The line redefined an input parameter for the t-slope.