### PR TITLE
Fixed genr8 initialization problem.

### DIFF
--- a/src/programs/Simulation/genr8/genr8.cc
+++ b/src/programs/Simulation/genr8/genr8.cc
@@ -529,6 +529,9 @@ l0:   imassc2=0;
     if(!(X->width<0)) 
       do{/*use BreitWigner--phasespace distribution */
 	initMass(X);
+        initMass(Y);  // RM: Initialize the masses of the Y children before 
+                      // they're used in setMass(X).  Using them uninitialized leads to
+                      // unpredictable (and hard to debug) consequences!
 	setMass(X);
 
 	/*


### PR DESCRIPTION
Initialize the masses of particles coming from the lower vertex.  They were previously uninitialized, leading to unpredictable behavior.