### PR TITLE
Fixed memory leak in CUDA kernel for Piecewise amplitude

### DIFF
--- a/src/libraries/AMPTOOLS_AMPS/GPUPiecewise_kernel.cu
+++ b/src/libraries/AMPTOOLS_AMPS/GPUPiecewise_kernel.cu
@@ -39,4 +39,8 @@ GPUPiecewise_exec(dim3 dimGrid, dim3 dimBlock, GPU_AMP_PROTO, GDouble* params1, 
   cudaMemcpy(d_params2, &params2[0], nBins * sizeof(GDouble), cudaMemcpyHostToDevice );
 
   GPUPiecewise_kernel<<< dimGrid, dimBlock >>>(GPU_AMP_ARGS, d_params1, d_params2, nBins, represReIm);
+
+  cudaDeviceSynchronize();
+  cudaFree(d_params1);
+  cudaFree(d_params2);
 }


### PR DESCRIPTION
spotted by @mashephe. This fixes a memory leak that leads to our fit application crashing after many fit iterations. 