### PR TITLE
reinitializePars by default

### DIFF
--- a/src/programs/AmplitudeAnalysis/fit/fit.cc
+++ b/src/programs/AmplitudeAnalysis/fit/fit.cc
@@ -113,6 +113,9 @@ void runRndFits(ConfigurationInfo* cfgInfo, bool useMinos, bool hesse, int maxIt
     cout << "FIT " << i << " OF " << numRnd << endl;
     cout << endl << "###############################" << endl;
 
+    // re-initialize parameters from configuration file (reset those not randomized)
+    ati.reinitializePars();
+
     // randomize parameters
     ati.randomizeProductionPars(maxFraction);
     for(size_t ipar=0; ipar<parRangeKeywords.size(); ipar++) {

--- a/src/programs/AmplitudeAnalysis/fitMPI/fitMPI.cc
+++ b/src/programs/AmplitudeAnalysis/fitMPI/fitMPI.cc
@@ -130,6 +130,9 @@ void runRndFits(ConfigurationInfo* cfgInfo, bool useMinos, bool hesse, int maxIt
          cout << "FIT " << i << " OF " << numRnd << endl;
          cout << endl << "###############################" << endl;
 
+	 // re-initialize parameters from configuration file (reset those not randomized)
+	 ati.reinitializePars();
+
          // randomize parameters
          ati.randomizeProductionPars(maxFraction);
          for(size_t ipar=0; ipar<parRangeKeywords.size(); ipar++) {


### PR DESCRIPTION
For fits with randomized starting parameters, execute reinitializePars() to restore parameter values from configuration file, so they're not carried over between randomized fit iterations.  Addresses behavior described in issue #281