### PR TITLE
Use the content of a histogram saved in external root file to weight the events

### DIFF
--- a/src/libraries/AMPTOOLS_DATAIO/ROOTDataReaderHist.cc
+++ b/src/libraries/AMPTOOLS_DATAIO/ROOTDataReaderHist.cc
@@ -1,0 +1,111 @@
+
+#include <vector>
+#include <cassert>
+#include <iostream>
+
+#include "TLorentzVector.h"
+
+#include "AMPTOOLS_DATAIO/ROOTDataReaderHist.h"
+#include "IUAmpTools/Kinematics.h"
+
+#include "TH1.h"
+#include "TFile.h"
+#include "TTree.h"
+
+using namespace std;
+
+ROOTDataReaderHist::ROOTDataReaderHist( const vector< string >& args ):
+  UserDataReader< ROOTDataReaderHist >( args ),
+  m_eventCounter( 0 ),
+  m_useWeight( false )
+{
+  assert( args.size() == 3 );
+  
+  TH1::AddDirectory( kFALSE );
+  
+  //this way of opening files works with URLs of the form
+  // root://xrootdserver/path/to/myfile.root
+  m_inFile = TFile::Open( args[0].c_str() );
+  
+  // default to tree name of "kin"
+  m_inTree = dynamic_cast<TTree*>( m_inFile->Get( "kin" ) );
+  
+  m_inTree->SetBranchAddress( "NumFinalState", &m_nPart );
+  m_inTree->SetBranchAddress( "E_FinalState", m_e );
+  m_inTree->SetBranchAddress( "Px_FinalState", m_px );
+  m_inTree->SetBranchAddress( "Py_FinalState", m_py );
+  m_inTree->SetBranchAddress( "Pz_FinalState", m_pz );
+  m_inTree->SetBranchAddress( "E_Beam", &m_eBeam );
+  m_inTree->SetBranchAddress( "Px_Beam", &m_pxBeam );
+  m_inTree->SetBranchAddress( "Py_Beam", &m_pyBeam );
+  m_inTree->SetBranchAddress( "Pz_Beam", &m_pzBeam );
+
+  if(m_inTree->GetBranch("Weight") != NULL) {
+
+    m_useWeight = true;
+    m_inTree->SetBranchAddress( "Weight", &m_weight );
+  }
+  else{
+
+    m_useWeight = false;
+  }
+  
+  //root file name provided as argument
+  m_HistFile = TFile::Open( args[1].c_str() );
+  //second argument: histogram name 
+  m_Hist = dynamic_cast<TH1F*>( m_HistFile->Get( args[2].c_str() ) );
+
+}
+
+ROOTDataReaderHist::~ROOTDataReaderHist()
+{
+  if( m_inFile != NULL ) m_inFile->Close();
+}
+
+void
+ROOTDataReaderHist::resetSource()
+{
+	
+  cout << "Resetting source " << m_inTree->GetName() 
+       << " in " << m_inFile->GetName() << endl;
+  
+  // this will cause the read to start back at event 0
+  m_eventCounter = 0;
+}
+
+Kinematics*
+ROOTDataReaderHist::getEvent()
+{
+  if( m_eventCounter < static_cast< unsigned int >( m_inTree->GetEntries() ) ){
+    //  if( m_eventCounter < 10 ){
+    
+    m_inTree->GetEntry( m_eventCounter++ );
+    assert( m_nPart < Kinematics::kMaxParticles );
+    
+    vector< TLorentzVector > particleList;
+    
+    particleList.
+      push_back( TLorentzVector( m_pxBeam, m_pyBeam, m_pzBeam, m_eBeam ) );
+    
+    for( int i = 0; i < m_nPart; ++i ){
+      
+      particleList.push_back( TLorentzVector( m_px[i], m_py[i], m_pz[i], m_e[i] ) );
+    }
+
+    double mass = (particleList[2]+particleList[3]).M();
+    m_weight = m_Hist->GetBinContent(m_Hist->FindBin(mass));
+    //cout << m_weight << endl;
+    
+    return new Kinematics( particleList, m_useWeight ? m_weight : 1.0 );
+  }
+  else{
+    
+    return NULL;
+  }
+}
+
+unsigned int
+ROOTDataReaderHist::numEvents() const
+{	
+  return static_cast< unsigned int >( m_inTree->GetEntries() );
+}

--- a/src/libraries/AMPTOOLS_DATAIO/ROOTDataReaderHist.cc
+++ b/src/libraries/AMPTOOLS_DATAIO/ROOTDataReaderHist.cc
@@ -92,11 +92,10 @@ ROOTDataReaderHist::getEvent()
       particleList.push_back( TLorentzVector( m_px[i], m_py[i], m_pz[i], m_e[i] ) );
     }
 
-    double mass = (particleList[2]+particleList[3]).M();
-    m_weight = m_Hist->GetBinContent(m_Hist->FindBin(mass));
-    //cout << m_weight << endl;
+    float mass = (particleList[2]+particleList[3]).M();
+    float hist_weight = m_Hist->GetBinContent(m_Hist->FindBin(mass));
     
-    return new Kinematics( particleList, m_useWeight ? m_weight : 1.0 );
+    return new Kinematics( particleList, m_useWeight ? m_weight*hist_weight : hist_weight );
   }
   else{
     

--- a/src/libraries/AMPTOOLS_DATAIO/ROOTDataReaderHist.h
+++ b/src/libraries/AMPTOOLS_DATAIO/ROOTDataReaderHist.h
@@ -1,0 +1,69 @@
+#if !defined(ROOTDATAREADERHIST)
+#define ROOTDATAREADERHIST
+
+#include "IUAmpTools/Kinematics.h"
+#include "IUAmpTools/UserDataReader.h"
+
+#include "TString.h"
+#include "TFile.h"
+#include "TTree.h"
+#include "TH1.h"
+
+#include <string>
+
+using namespace std;
+
+class ROOTDataReaderHist : public UserDataReader< ROOTDataReaderHist >
+{
+	
+public:
+  
+  /**
+   * Default constructor for ROOTDataReaderHist
+   */
+  ROOTDataReaderHist() : UserDataReader< ROOTDataReaderHist >(), m_inFile( NULL ) { }
+  
+  ~ROOTDataReaderHist();
+  
+  /**
+   * Constructor for ROOTDataReaderHist
+   * \param[in] args vector of string arguments
+   */
+  ROOTDataReaderHist( const vector< string >& args );
+  
+  string name() const { return "ROOTDataReaderHist"; }
+  
+  virtual Kinematics* getEvent();
+  virtual void resetSource();
+
+  /**
+   * This function returns a true if the file was open
+   * with weight-reading enabled and had this tree branch,
+   * false, if these criteria are not met.
+   */
+  virtual bool hasWeight(){ return m_useWeight; };
+  virtual unsigned int numEvents() const;
+  
+private:
+	
+  TFile* m_inFile;
+  TTree* m_inTree;
+  unsigned int m_eventCounter;
+  bool m_useWeight;
+  
+  int m_nPart;
+  float m_e[Kinematics::kMaxParticles];
+  float m_px[Kinematics::kMaxParticles];
+  float m_py[Kinematics::kMaxParticles];
+  float m_pz[Kinematics::kMaxParticles];
+  float m_eBeam;
+  float m_pxBeam;
+  float m_pyBeam;
+  float m_pzBeam;
+  float m_weight;
+
+  TFile* m_HistFile;
+  TH1F* m_Hist;
+};
+
+#endif

--- a/src/programs/AmplitudeAnalysis/fit/fit.cc
+++ b/src/programs/AmplitudeAnalysis/fit/fit.cc
@@ -13,6 +13,7 @@
 #include "AMPTOOLS_DATAIO/ROOTDataReaderBootstrap.h"
 #include "AMPTOOLS_DATAIO/ROOTDataReaderWithTCut.h"
 #include "AMPTOOLS_DATAIO/ROOTDataReaderTEM.h"
+#include "AMPTOOLS_DATAIO/ROOTDataReaderHist.h"
 #include "AMPTOOLS_DATAIO/FSRootDataReader.h"
 #include "AMPTOOLS_AMPS/TwoPSAngles.h"
 #include "AMPTOOLS_AMPS/TwoPSHelicity.h"
@@ -339,6 +340,7 @@ int main( int argc, char* argv[] ){
    AmpToolsInterface::registerDataReader( ROOTDataReaderBootstrap() );
    AmpToolsInterface::registerDataReader( ROOTDataReaderWithTCut() );
    AmpToolsInterface::registerDataReader( ROOTDataReaderTEM() );
+   AmpToolsInterface::registerDataReader( ROOTDataReaderHist() );
    AmpToolsInterface::registerDataReader( FSRootDataReader() );
 
    if(numRnd==0){

--- a/src/programs/AmplitudeAnalysis/twopi_plotter/twopi_plotter.cc
+++ b/src/programs/AmplitudeAnalysis/twopi_plotter/twopi_plotter.cc
@@ -20,6 +20,7 @@
 
 #include "AMPTOOLS_DATAIO/TwoPiPlotGenerator.h"
 #include "AMPTOOLS_DATAIO/ROOTDataReader.h"
+#include "AMPTOOLS_DATAIO/ROOTDataReaderHist.h"
 #include "AMPTOOLS_AMPS/Zlm.h"
 #include "AMPTOOLS_AMPS/TwoPiAngles.h"
 #include "AMPTOOLS_AMPS/BreitWigner.h"
@@ -32,6 +33,7 @@ void atiSetup(){
   AmpToolsInterface::registerAmplitude( TwoPiAngles() );
   AmpToolsInterface::registerAmplitude( BreitWigner() );
   AmpToolsInterface::registerDataReader( ROOTDataReader() );
+  AmpToolsInterface::registerDataReader( ROOTDataReaderHist() );
 }
 
 using namespace std;


### PR DESCRIPTION
Usage: ROOTDataReaderHist <1> <2> <3>
where 
<1> the input root file which contains the tree "kin"
<2> the root file containing a TH1F histogram with the weights
<3> the name of the TH1F

In this special case, the weight is applied to the invariant mass of the particles 2+3, but the code can be easily adapted to weight the events according to any other kinematic distribution. Any weights in the input tree are overwritten.