### PR TITLE
LowerVertexDelta amplitude class

### DIFF
--- a/src/libraries/AMPTOOLS_AMPS/GPULowerVertexDelta.cu
+++ b/src/libraries/AMPTOOLS_AMPS/GPULowerVertexDelta.cu
@@ -1,0 +1,41 @@
+#include <stdio.h>
+
+#include "GPUManager/GPUCustomTypes.h"
+#include "GPUManager/CUDA-Complex.cuh"
+
+#include "GPUUtils/wignerD.cuh"
+///////////////////////////////////////////////////////////////////////////////
+__device__ WCUComplex CZero = { 0, 0 };
+///////////////////////////////////////////////////////////////////////////////
+__global__ void
+GPULowerVertexDelta_kernel( GPU_AMP_PROTO, int m_d, int m_p, int m_c, int m_s )
+{
+	int iEvent = GPU_THIS_EVENT;
+
+	GDouble cosTheta = GPU_UVARS(0);
+	GDouble phi = GPU_UVARS(1);
+	
+	GDouble lambda_Delta = m_d / 2.;
+	GDouble lambda_proton = m_p / 2.;
+	
+	WCUComplex amp = CZero;
+
+	if ( m_c == 1 )
+		amp = 2/3.* m_s * wignerD( 3/2, lambda_Delta, lambda_proton, cosTheta, phi );
+	if ( m_c == -1 )
+		amp = 2/3.* m_s * Conjugate( wignerD( 3/2, lambda_Delta, lambda_proton, cosTheta, phi ) );
+
+	pcDevAmp[iEvent] = amp;
+
+}
+
+void
+GPULowerVertexDelta_exec( dim3 dimGrid, dim3 dimBlock, GPU_AMP_PROTO, int m_d, int m_p, int m_c, int m_s )
+
+{
+
+	GPULowerVertexDelta_kernel<<< dimGrid, dimBlock >>>
+		( GPU_AMP_ARGS, m_d, m_p, m_c, m_s );
+
+}
+

--- a/src/libraries/AMPTOOLS_AMPS/GPUSinglePS_kernel.cu
+++ b/src/libraries/AMPTOOLS_AMPS/GPUSinglePS_kernel.cu
@@ -1,0 +1,48 @@
+
+#include <stdio.h>
+
+#include "GPUManager/GPUCustomTypes.h"
+#include "GPUManager/CUDA-Complex.cuh"
+
+////////////////////////////////////////////////////////////////////////////////////////
+ __device__ WCUComplex CZero = { 0, 0 };
+ __device__ WCUComplex COne  = { 1, 0 };
+ __device__ WCUComplex ic  = { 0, 1 };
+
+ __device__ GDouble DegToRad = PI/180.0;
+///////////////////////////////////////////////////////////////////////////////
+__global__ void
+GPUSinglePS_kernel( GPU_AMP_PROTO, int m_r, int m_s )
+{
+	int iEvent = GPU_THIS_EVENT;
+
+	GDouble prod_angle = GPU_UVARS(0);
+	GDouble polFraction = GPU_UVARS(1);
+	GDouble polAngle = GPU_UVARS(2);
+	
+	///////////////////////////////////////////////////////////////////////////////////////////
+
+	WCUComplex amplitude = CZero;
+
+  
+	GDouble Factor = sqrt(1 + m_s * polFraction);
+	WCUComplex rotateY = { G_COS(  -1. * (prod_angle + polAngle*DegToRad) ) , G_SIN( -1. * (prod_angle + polAngle*DegToRad) ) }; // prod_angle and polAngle should be added
+
+	if (m_r == 1)
+		amplitude = ( rotateY ).m_dRe;
+	if (m_r == -1) 
+		amplitude = ic * ( rotateY ).m_dIm;
+		
+  	pcDevAmp[iEvent] = amplitude * Factor;
+}
+
+void
+GPUSinglePS_exec( dim3 dimGrid, dim3 dimBlock, GPU_AMP_PROTO, int m_r, int m_s )
+
+{  
+
+  	GPUSinglePS_kernel<<< dimGrid, dimBlock >>>
+    		( GPU_AMP_ARGS, m_r, m_s );
+
+}
+

--- a/src/libraries/AMPTOOLS_AMPS/LowerVertexDelta.cc
+++ b/src/libraries/AMPTOOLS_AMPS/LowerVertexDelta.cc
@@ -1,0 +1,91 @@
+
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <cstdlib>
+
+#include "TLorentzVector.h"
+#include "TLorentzRotation.h"
+
+#include "IUAmpTools/Kinematics.h"
+#include "AMPTOOLS_AMPS/LowerVertexDelta.h"
+#include "AMPTOOLS_AMPS/clebschGordan.h"
+#include "AMPTOOLS_AMPS/wignerD.h"
+#include "AMPTOOLS_AMPS/decayAngles.h"
+
+LowerVertexDelta::LowerVertexDelta( const vector< string >& args ) :
+UserAmplitude< LowerVertexDelta >( args )
+{
+	assert( args.size() == 5 );
+
+	m_d = atoi( args[0].c_str() ); // Twice the helicity of decaying Delta baryon: (3,1,-1, or -3)
+	m_p = atoi( args[1].c_str() ); // Twice the helicity of final state proton (+/-1)
+	m_c = atoi( args[2].c_str() ); // Wigner D function (+1) or its complex conjugate (-1)
+	m_s = atoi( args[3].c_str() ); // The amplitude gets multiplied by a positive or negative sign
+
+	lowerVertex = args[4].c_str(); // indices of proton and pi+ from the lower vertex
+
+	// make sure values are reasonable
+	assert( abs( m_d ) == 1 || abs( m_d ) == 3 );
+	assert( abs( m_p ) == 1 );
+	assert( abs( m_c ) == 1 );
+	assert( abs( m_s ) == 1 );
+}
+
+
+complex< GDouble >
+LowerVertexDelta::calcAmplitude( GDouble** pKin, GDouble* userVars ) const {	
+
+	GDouble phi		= userVars[kPhi];
+	GDouble cosTheta	= userVars[kCosTheta];
+
+	GDouble lambda_Delta 	= m_d / 2.;
+	GDouble lambda_proton 	= m_p / 2.;
+
+	complex <GDouble> amplitude;
+	if( m_c == 1 ){
+		amplitude = 2/3. * m_s * wignerD( 3/2., lambda_Delta, lambda_proton, cosTheta, phi );
+	}
+	else{
+		amplitude = 2/3. * m_s * conj( wignerD( 3/2., lambda_Delta, lambda_proton, cosTheta, phi ) );
+	}
+
+	return amplitude;		
+}
+
+void
+LowerVertexDelta::calcUserVars( GDouble** pKin, GDouble* userVars ) const {
+
+	TLorentzVector target ( 0, 0, 0, 0.9382720813);
+	TLorentzVector beam   ( pKin[0][1], pKin[0][2], pKin[0][3], pKin[0][0] ); 
+	TLorentzVector p1, p2, pDelta;
+	
+	string lv1; lv1 += lowerVertex[0];
+	string lv2; lv2 += lowerVertex[1];
+
+        int index1 = atoi( lv1.c_str() );     
+	int index2 = atoi( lv2.c_str() );
+
+	p1.SetPxPyPzE( pKin[index1][1], pKin[index1][2], pKin[index1][3], pKin[index1][0] );
+	p2.SetPxPyPzE( pKin[index2][1], pKin[index2][2], pKin[index2][3], pKin[index2][0] );
+
+	pDelta = p1 + p2;
+	
+	vector< double > thetaPhi = getOneStepAngles( pDelta, p1, beam, target, 2, false );
+
+	userVars[kCosTheta] 	= TMath::Cos( thetaPhi[0] );
+	userVars[kPhi]		= thetaPhi[1];
+
+	return;
+}
+
+#ifdef GPU_ACCELERATION
+void
+LowerVertexDelta::launchGPUKernel( dim3 dimGrid, dim3 dimBlock, GPU_AMP_PROTO ) const {
+
+	GPULowerVertexDelta_exec( dimGrid, dimBlock, GPU_AMP_ARGS,
+			m_d, m_p, m_c, m_s );
+}
+
+#endif // GPU_ACCELERATION

--- a/src/libraries/AMPTOOLS_AMPS/LowerVertexDelta.h
+++ b/src/libraries/AMPTOOLS_AMPS/LowerVertexDelta.h
@@ -1,0 +1,62 @@
+#if !defined(LOWERVERTEXDELTA)
+#define LOWERVERTEXDELTA
+
+#include "IUAmpTools/Amplitude.h"
+#include "IUAmpTools/UserAmplitude.h"
+#include "IUAmpTools/AmpParameter.h"
+#include "GPUManager/GPUCustomTypes.h"
+
+#include "TH1D.h"
+
+#include <string>
+#include <complex>
+#include <vector>
+
+
+
+using std::complex;
+using namespace std;
+
+#ifdef GPU_ACCELERATION
+void GPULowerVertexDelta_exec( dim3 dimGrid, dim3 dimBlock, GPU_AMP_PROTO, int m_d, int m_p, int m_c, int m_s );
+#endif // GPU_ACCELERATION
+
+
+class Kinematics;
+
+class LowerVertexDelta : public UserAmplitude< LowerVertexDelta >
+{
+    
+public:
+	
+	LowerVertexDelta() : UserAmplitude< LowerVertexDelta >() { };
+	LowerVertexDelta( const vector< string >& args );
+	LowerVertexDelta( int m_d, int m_p, int m_c, int m_s );
+
+	enum UserVars { kCosTheta = 0, kPhi = 1, kNumUserVars };
+	unsigned int numUserVars() const { return kNumUserVars; }
+	
+	string name() const { return "LowerVertexDelta"; }
+    
+	complex< GDouble > calcAmplitude( GDouble** pKin, GDouble* userVars ) const;
+	void calcUserVars( GDouble** pKin, GDouble* userVars ) const;
+
+	bool needsUserVarsOnly() const { return true; }
+
+#ifdef GPU_ACCELERATION
+
+	void launchGPUKernel( dim3 dimGrid, dim3 dimBlock, GPU_AMP_PROTO ) const;
+	bool isGPUEnabled() const { return true; }
+
+#endif // GPU_ACCELERATION
+  
+private:
+	int m_d;
+	int m_p;
+	int m_c;  
+	int m_s;
+
+	string lowerVertex;
+};
+
+#endif

--- a/src/libraries/AMPTOOLS_AMPS/SinglePS.cc
+++ b/src/libraries/AMPTOOLS_AMPS/SinglePS.cc
@@ -21,20 +21,14 @@
 SinglePS::SinglePS( const vector< string >& args ) :
 UserAmplitude< SinglePS >( args )
 {
-  //assert( args.size() == 11 );
-  
-  
-//  m_j = atoi( args[0].c_str() ); // resonance spin J
-//  m_m = atoi( args[1].c_str() ); // spin projection (Lambda)
-//  m_l = atoi( args[2].c_str() ); // partial wave L
   m_r = atoi( args[0].c_str() ); // real (+1) or imaginary (-1)
   m_s = atoi( args[1].c_str() ); // sign for polarization in amplitude
 
   // default polarization information stored in tree
   m_polInTree = true;
 
-  // 5 possibilities to initialize this amplitude:
-  // (with <J>: total spin, <m>: spin projection, <l>: partial wave, <r>: +1/-1 for real/imaginary part; <s>: +1/-1 sign in P_gamma term)
+  // 2 possibilities to initialize this amplitude:
+  // (with <r>: +1/-1 for real/imaginary part; <s>: +1/-1 sign in P_gamma term)
 
   // loop over any additional amplitude arguments to change defaults
   for( uint ioption = 2; ioption < args.size(); ioption++ ) {
@@ -50,7 +44,7 @@ UserAmplitude< SinglePS >( args )
 		  else if(polOption.Contains(".root")) {
 			  polFraction = 0.;
 			  TFile* f = new TFile( polOption );
-			  polFrac_vs_E = (TH1D*)f->Get( args[7].c_str() );
+			  polFrac_vs_E = (TH1D*)f->Get( args[4].c_str() );
 			  assert( polFrac_vs_E != NULL );
 		  }
 		  else {
@@ -61,7 +55,6 @@ UserAmplitude< SinglePS >( args )
   }
 
   // make sure values are reasonable
-//  assert( abs( m_m ) <= m_j );
   // m_r = +1 for real
   // m_r = -1 for imag
   assert( abs( m_r ) == 1 );

--- a/src/libraries/AMPTOOLS_AMPS/SinglePS.cc
+++ b/src/libraries/AMPTOOLS_AMPS/SinglePS.cc
@@ -1,0 +1,177 @@
+
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <cstdlib>
+
+#include "TLorentzVector.h"
+#include "TLorentzRotation.h"
+#include "TFile.h"
+
+#include "IUAmpTools/Kinematics.h"
+#include "AMPTOOLS_AMPS/SinglePS.h"
+#include "AMPTOOLS_AMPS/clebschGordan.h"
+#include "AMPTOOLS_AMPS/wignerD.h"
+#include "AMPTOOLS_AMPS/barrierFactor.h"
+#include "AMPTOOLS_AMPS/decayAngles.h"
+
+#include "UTILITIES/BeamProperties.h"
+
+SinglePS::SinglePS( const vector< string >& args ) :
+UserAmplitude< SinglePS >( args )
+{
+  //assert( args.size() == 11 );
+  
+  
+//  m_j = atoi( args[0].c_str() ); // resonance spin J
+//  m_m = atoi( args[1].c_str() ); // spin projection (Lambda)
+//  m_l = atoi( args[2].c_str() ); // partial wave L
+  m_r = atoi( args[0].c_str() ); // real (+1) or imaginary (-1)
+  m_s = atoi( args[1].c_str() ); // sign for polarization in amplitude
+
+  // default polarization information stored in tree
+  m_polInTree = true;
+
+  // 5 possibilities to initialize this amplitude:
+  // (with <J>: total spin, <m>: spin projection, <l>: partial wave, <r>: +1/-1 for real/imaginary part; <s>: +1/-1 sign in P_gamma term)
+
+  // loop over any additional amplitude arguments to change defaults
+  for( uint ioption = 2; ioption < args.size(); ioption++ ) {
+	  TString option = args[ioption].c_str();
+
+	  // polarization provided in configuration file
+	  if( ioption == 2 && option.IsFloat() ) {
+		  m_polInTree = false;
+		  polAngle = atof( args[2].c_str() );
+	  
+		  TString polOption = args[3].c_str();
+		  if( polOption.IsFloat() ) polFraction = atof( polOption.Data() );
+		  else if(polOption.Contains(".root")) {
+			  polFraction = 0.;
+			  TFile* f = new TFile( polOption );
+			  polFrac_vs_E = (TH1D*)f->Get( args[7].c_str() );
+			  assert( polFrac_vs_E != NULL );
+		  }
+		  else {
+			  cout << "ERROR: SinglePS beam polarization not set" <<endl;
+			  assert(0);
+		  }
+	  }
+  }
+
+  // make sure values are reasonable
+//  assert( abs( m_m ) <= m_j );
+  // m_r = +1 for real
+  // m_r = -1 for imag
+  assert( abs( m_r ) == 1 );
+  // m_s = +1 for 1 + Pgamma
+  // m_s = -1 for 1 - Pgamma
+  assert( abs( m_s ) == 1 );
+  
+}
+
+void
+SinglePS::calcUserVars( GDouble** pKin, GDouble* userVars ) const {
+
+  TLorentzVector beam;
+  TVector3 eps;
+  double beam_polFraction;
+  double beam_polAngle;
+
+  if(m_polInTree){
+    beam.SetPxPyPzE( 0., 0., pKin[0][0], pKin[0][0]);
+    eps.SetXYZ(pKin[0][1], pKin[0][2], 0.); // beam polarization vector;
+
+    beam_polFraction = eps.Mag();
+    beam_polAngle = eps.Phi()*TMath::RadToDeg();
+  }
+  else {
+    beam.SetPxPyPzE( pKin[0][1], pKin[0][2], pKin[0][3], pKin[0][0] );
+    beam_polAngle = polAngle;
+    
+    if(polFraction > 0.) { // for fitting with fixed polarization
+	    beam_polFraction = polFraction;
+    }
+    else { // for fitting with polarization vs E_gamma from input histogram 
+	    int bin = polFrac_vs_E->GetXaxis()->FindBin(pKin[0][0]);
+	    if (bin == 0 || bin > polFrac_vs_E->GetXaxis()->GetNbins()){
+		    beam_polFraction = 0.;
+	    } else 
+		    beam_polFraction = polFrac_vs_E->GetBinContent(bin);
+    }
+  }
+  
+  TLorentzVector ps ( pKin[1][1], pKin[1][2], pKin[1][3], pKin[1][0] ); // pi-
+
+  TLorentzVector ps_recoil(pKin[2][1], pKin[2][2], pKin[2][3], pKin[2][0]); // pi+
+  TLorentzVector proton_recoil(pKin[3][1], pKin[3][2], pKin[3][3], pKin[3][0]); // proton
+
+  TLorentzVector recoil = ps_recoil + proton_recoil;
+
+  //////////////////////// Boost Particles and Get Angles//////////////////////////////////
+
+  TLorentzVector target(0,0,0,0.938);
+  //Helicity coordinate system
+  TLorentzVector Gammap = beam + target;
+
+  // set beam polarization angle to 0 degrees; apply diamond orientation in calcAmplitude
+  double phiProd = getPhiProd( 0., recoil, beam, target, 2, false ); 
+
+  userVars[uv_prod_Phi] = phiProd;
+
+  userVars[uv_beam_polFraction] = beam_polFraction;
+  userVars[uv_beam_polAngle] = beam_polAngle;
+
+  return;
+}
+
+
+////////////////////////////////////////////////// Amplitude Calculation //////////////////////////////////
+
+complex< GDouble >
+SinglePS::calcAmplitude( GDouble** pKin, GDouble* userVars ) const
+{
+  GDouble prod_angle = userVars[uv_prod_Phi];
+  GDouble beam_polFraction = userVars[uv_beam_polFraction];
+  GDouble beam_polAngle = userVars[uv_beam_polAngle];
+
+  complex <GDouble> amplitude(0,0);
+  complex <GDouble> i(0,1);
+
+  GDouble Factor = sqrt(1 + m_s * beam_polFraction);
+  
+  complex< GDouble > rotateY = polar( (GDouble)1., (GDouble)(-1.*(prod_angle + beam_polAngle*TMath::DegToRad())) ); // - -> + in prod_angle and polAngle summing
+  
+  if( m_r == 1 )
+	  amplitude = real( rotateY );
+  if( m_r == -1 ) 
+	  amplitude = i*imag( rotateY );
+
+  // E852 Nozar thesis has sqrt(2*s+1)*sqrt(2*l+1)*F_l(p_omega)*sqrt(omega)
+//  double kinFactor = barrierFactor(MX, m_l, MVec, MPs);
+  //kinFactor *= sqrt(3.) * sqrt(2.*m_l + 1.);
+//  Factor *= kinFactor;
+
+  return complex< GDouble >( static_cast< GDouble>( Factor ) * amplitude );
+}
+
+
+void SinglePS::updatePar( const AmpParameter& par ){
+
+  // could do expensive calculations here on parameter updates  
+}
+
+
+#ifdef GPU_ACCELERATION
+
+void
+SinglePS::launchGPUKernel( dim3 dimGrid, dim3 dimBlock, GPU_AMP_PROTO ) const {
+
+	GPUSinglePS_exec( dimGrid, dimBlock, GPU_AMP_ARGS, m_r, m_s );
+
+}
+
+#endif
+
+

--- a/src/libraries/AMPTOOLS_AMPS/SinglePS.h
+++ b/src/libraries/AMPTOOLS_AMPS/SinglePS.h
@@ -1,0 +1,87 @@
+#if !defined(VEC_PS_REFL)
+#define VEC_PS_REFL
+
+#include "IUAmpTools/Amplitude.h"
+#include "IUAmpTools/UserAmplitude.h"
+#include "IUAmpTools/AmpParameter.h"
+#include "GPUManager/GPUCustomTypes.h"
+
+#include "TH1D.h"
+#include <string>
+#include <complex>
+#include <vector>
+
+using std::complex;
+using namespace std;
+
+#ifdef GPU_ACCELERATION
+void
+GPUSinglePS_exec( dim3 dimGrid, dim3 dimBlock, GPU_AMP_PROTO, int m_r, int m_s );
+#endif
+
+class Kinematics;
+
+class SinglePS : public UserAmplitude< SinglePS >
+{
+    
+public:
+	
+	SinglePS() : UserAmplitude< SinglePS >() { };
+	SinglePS( const vector< string >& args );
+	SinglePS( int m_r, int m_s );
+	
+	string name() const { return "SinglePS"; }
+    
+	complex< GDouble > calcAmplitude( GDouble** pKin, GDouble* userVars ) const;
+
+	// **********************
+	// The following lines are optional and can be used to precalcualte
+	// user-defined data that the amplitudes depend on.
+	
+	// Use this for indexing a user-defined data array and notifying
+	// the framework of the number of user-defined variables.
+	
+	enum UserVars { uv_prod_Phi = 0, uv_beam_polFraction = 1, uv_beam_polAngle = 2, kNumUserVars };
+	unsigned int numUserVars() const { return kNumUserVars; }
+	
+	// This function needs to be defined -- see comments and discussion
+	// in the .cc file.
+	void calcUserVars( GDouble** pKin, GDouble* userVars ) const;
+	
+	// This is an optional addition if the calcAmplitude routine
+	// can run with only the user-defined data and not the original
+	// four-vectors.  It is used to optimize memory usage in GPU
+	// based fits.
+	bool needsUserVarsOnly() const { return true; }
+	
+	// This is an optional addition if the UserVars are the same for each 
+	// instance of an amplitude.  If it is not used, the memory footprint
+	// grows dramatically as UserVars values are stored for each instance
+	// of the amplitude.  NOTE: To use this make sure that UserVars only 
+	// depend on kinematics and no arguments provided to the amplitude!
+	bool areUserVarsStatic() const { return true; }
+
+	void updatePar( const AmpParameter& par );
+
+#ifdef GPU_ACCELERATION
+
+	void launchGPUKernel( dim3 dimGrid, dim3 dimBlock, GPU_AMP_PROTO ) const;
+
+        bool isGPUEnabled() const { return true; }
+
+#endif // GPU_ACCELERATION
+	
+private:
+        
+	int m_r;
+	int m_s;
+
+	
+	//AmpParameter polAngle;
+	double polFraction;
+	double polAngle;
+	bool m_polInTree;
+	TH1D *polFrac_vs_E;
+};
+
+#endif

--- a/src/libraries/AMPTOOLS_AMPS/SinglePS.h
+++ b/src/libraries/AMPTOOLS_AMPS/SinglePS.h
@@ -76,6 +76,7 @@ private:
 	int m_r;
 	int m_s;
 
+	string lowerVertex;
 	
 	//AmpParameter polAngle;
 	double polFraction;

--- a/src/libraries/AMPTOOLS_AMPS/SinglePS.h
+++ b/src/libraries/AMPTOOLS_AMPS/SinglePS.h
@@ -1,5 +1,5 @@
-#if !defined(VEC_PS_REFL)
-#define VEC_PS_REFL
+#if !defined(SINGLEPS)
+#define SINGLEPS
 
 #include "IUAmpTools/Amplitude.h"
 #include "IUAmpTools/UserAmplitude.h"

--- a/src/libraries/AMPTOOLS_AMPS/decayAngles.cc
+++ b/src/libraries/AMPTOOLS_AMPS/decayAngles.cc
@@ -1,0 +1,251 @@
+//Goal: Calculate the decay angles for X->omegapi->4pi or Delta->protonpi decay, in either the helicity or Gottfried-Jackson reference frames. Inputs should be the relevant 4-momentum vectors in the lab frame, an integer flag specifying the desired reference frame, and a boolean specifying whether the decay happens at the upper or lower vertex of the t-channel reaction
+//Gottfried-Jackson RF: The z-axis is equal to the direction of flight of the incoming beam photon in the parent rest frame.
+//Adair RF: The z-axis is equal to the direction of flight of the incoming beam photon in the center of mass system.
+
+#include <ctime>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <sstream>
+
+
+#include "TLorentzVector.h"
+#include "TLorentzRotation.h"
+
+#include "decayAngles.h"
+
+#include <cmath>
+#include <complex>
+#include <vector>
+#include "TMath.h"
+
+// Calculate the x, y, and z axes in the helicity reference frame
+vector< TVector3 > getHelicityAxes(TVector3 parentCM, TVector3 inverseCM)
+{
+	TVector3 z = parentCM.Unit();
+	TVector3 y = ( inverseCM.Unit() ).Cross( parentCM.Unit() ).Unit();
+	TVector3 x = y.Cross( z );
+
+	vector< TVector3 > xyz{x, y, z};
+	return xyz;
+} 
+
+// Calculate the x, y, and z axes in the Gottfried-Jackson reference frame
+vector< TVector3 > getGJAxes(TVector3 parentCM, TVector3 inverseCM, TVector3 inverseParent)
+{
+	TVector3 z = inverseParent.Unit();
+	TVector3 y = ( inverseCM.Unit() ).Cross( parentCM.Unit() ).Unit();
+	TVector3 x = y.Cross( z );
+
+	vector< TVector3 > xyz{x, y, z};
+	return xyz;
+}
+
+// Calculate production plane angle
+double getPhiProd(double polAngle, TLorentzVector parentLab, TLorentzVector beamLab, TLorentzVector targetLab, int whichFrame, bool upperVertex)
+{
+	// whichFrame = 1 for helicity, 2 for GJ
+	assert( whichFrame == 1 || whichFrame == 2 );
+
+	// Boost all P4 from lab to CM rest frame
+	TLorentzVector cmLab = beamLab + targetLab;
+	TVector3 boostCMToLab = cmLab.BoostVector();
+
+	TLorentzVector parentCM = parentLab;
+	TLorentzVector inverseLab;
+	if( upperVertex == false )
+		inverseLab = targetLab;
+	else
+		inverseLab = beamLab;
+	TLorentzVector inverseCM = inverseLab;			
+	parentCM.Boost( -1.0*boostCMToLab );
+	inverseCM.Boost( -1.0*boostCMToLab );
+
+	TVector3 boostParentToCM = parentCM.BoostVector();
+	TLorentzVector inverseParent = inverseCM;
+	inverseParent.Boost( -1.0*boostParentToCM );
+
+	// convert P4s to P3
+	TVector3 parentCM3 = parentCM.Vect();
+	TVector3 inverseCM3 = inverseCM.Vect();
+	TVector3 inverseParent3 = inverseParent.Vect();
+
+	vector< TVector3 > locxyz;
+	if( whichFrame == 1 )
+		locxyz = getHelicityAxes(parentCM3, inverseCM3);
+	else
+		locxyz = getGJAxes(parentCM3, inverseCM3, inverseParent3);
+
+	TVector3 y = locxyz[1];
+
+	TVector3 eps( cos( polAngle ), sin( polAngle ), 0.0 );
+
+	double phiProd = atan2( y.Dot( eps ), inverseLab.Vect().Unit().Dot( eps.Cross( y ) ) );
+
+	return phiProd;	
+} 
+
+
+// Calculate angles for a one-step decay. If only one of the daughter particles has spin, that one should be used in this calculation 
+vector< double > getOneStepAngles(TLorentzVector parentLab, TLorentzVector daughterLab, TLorentzVector beamLab, TLorentzVector targetLab, int whichFrame, bool upperVertex)
+{
+	// whichFrame = 1 for helicity, 2 for GJ
+	assert( whichFrame == 1 || whichFrame == 2 );
+
+	// Boost all P4 from lab to CM rest frame
+	TLorentzVector cmLab = beamLab + targetLab;
+	TVector3 boostCMToLab = cmLab.BoostVector();
+
+	TLorentzVector parentCM = parentLab;
+	TLorentzVector daughterCM = daughterLab;
+	TLorentzVector inverseCM;
+	if( upperVertex == false )
+		inverseCM = targetLab;
+	else
+		inverseCM = beamLab;
+	parentCM.Boost( -1.0*boostCMToLab );
+	daughterCM.Boost( -1.0*boostCMToLab );
+	inverseCM.Boost( -1.0*boostCMToLab );
+
+	// boost daughter and inverse to parent rest frame
+	TVector3 boostParentToCM = parentCM.BoostVector();
+	TLorentzVector daughterParent = daughterCM;
+	TLorentzVector inverseParent = inverseCM;
+	daughterParent.Boost( -1.0*boostParentToCM );
+	inverseParent.Boost( -1.0*boostParentToCM );
+
+	// convert P4s to P3
+	TVector3 parentCM3 = parentCM.Vect();
+	TVector3 inverseCM3 = inverseCM.Vect();
+	TVector3 inverseParent3 = inverseParent.Vect();
+
+	// define xyz axes in their own function (I think this will be useful later)
+	vector< TVector3 > locxyz;
+	if( whichFrame == 1 )
+		locxyz = getHelicityAxes(parentCM3, inverseCM3);
+	else
+		locxyz = getGJAxes(parentCM3, inverseCM3, inverseParent3);
+
+	TVector3 x = locxyz[0];
+	TVector3 y = locxyz[1];
+	TVector3 z = locxyz[2];
+
+	// project daughter in parent's rest frame onto xyz axes
+	TVector3 angles( daughterParent.Vect().Dot( x ),
+				daughterParent.Vect().Dot( y ),
+				daughterParent.Vect().Dot( z ) );
+
+	double theta = angles.Theta();
+	double phi = angles.Phi();
+
+	vector< double > thetaPhi{theta, phi};
+
+	return thetaPhi;
+}
+
+
+// Calculate angles for a two-step decay. This has been tested for photoproduction of a resonance decaying to omega and pi, with the omega subequently decaying to three pions. If the second step of the decay is a two-body decay, the input for granddaughter2Lab should be TLorentzVector(0,0,0,0)  
+vector< double > getTwoStepAngles(TLorentzVector parentLab, TLorentzVector daughterLab, TLorentzVector granddaughter1Lab, TLorentzVector granddaughter2Lab, TLorentzVector beamLab, TLorentzVector targetLab, int whichFrame, bool upperVertex)
+{
+	// whichFrame = 1 for helicity, 2 for GJ
+	assert( whichFrame == 1 || whichFrame == 2 );
+
+	// Boost all P4 from lab to CM rest frame
+	TLorentzVector cmLab = beamLab + targetLab;
+	TVector3 boostCMToLab = cmLab.BoostVector();
+
+	TLorentzVector parentCM = parentLab;
+	TLorentzVector daughterCM = daughterLab;
+	TLorentzVector granddaughter1CM = granddaughter1Lab;
+	TLorentzVector granddaughter2CM = granddaughter2Lab;
+	TLorentzVector inverseCM;
+	if( upperVertex == false )
+		inverseCM = targetLab;
+	else
+		inverseCM = beamLab;
+	parentCM.Boost( -1.0*boostCMToLab );
+	daughterCM.Boost( -1.0*boostCMToLab );
+	granddaughter1CM.Boost( -1.0*boostCMToLab );
+	granddaughter2CM.Boost( -1.0*boostCMToLab );
+	inverseCM.Boost( -1.0*boostCMToLab );
+
+	// boost daughter and inverse to parent rest frame
+	TVector3 boostParentToCM = parentCM.BoostVector();
+	TLorentzVector daughterParent = daughterCM;
+	TLorentzVector granddaughter1Parent = granddaughter1CM;
+	TLorentzVector granddaughter2Parent = granddaughter2CM;
+	TLorentzVector inverseParent = inverseCM;
+	daughterParent.Boost( -1.0*boostParentToCM );
+	granddaughter1Parent.Boost( -1.0*boostParentToCM );
+	granddaughter2Parent.Boost( -1.0*boostParentToCM );
+	inverseParent.Boost( -1.0*boostParentToCM );
+
+	// convert P4s to P3
+	TVector3 parentCM3 = parentCM.Vect();
+	TVector3 inverseCM3 = inverseCM.Vect();
+	TVector3 inverseParent3 = inverseParent.Vect();
+
+	// define xyz axes in their own function (I think this will be useful later)
+	vector< TVector3 > locxyz;
+	if( whichFrame == 1 )
+		locxyz = getHelicityAxes(parentCM3, inverseCM3);
+	else
+		locxyz = getGJAxes(parentCM3, inverseCM3, inverseParent3);
+
+	TVector3 x = locxyz[0];
+	TVector3 y = locxyz[1];
+	TVector3 z = locxyz[2];
+
+	// project daughter in parent's rest frame onto xyz axes
+	TVector3 daughterParent3 = daughterParent.Vect();
+	TVector3 angles( daughterParent3.Dot( x ),
+				daughterParent3.Dot( y ),
+				daughterParent3.Dot( z ) );
+
+	double theta = angles.Theta();
+	double phi = angles.Phi();
+
+	// Calculate decay of daughter particle in its helicity frame
+	// Boost granddaughter(s) to daughter's rest frame
+	TVector3 boostDaughterToParent = daughterParent.BoostVector();
+	TLorentzVector granddaughter1Daughter = granddaughter1Parent;	
+	TLorentzVector granddaughter2Daughter = granddaughter2Parent;
+	granddaughter1Daughter.Boost( -1.0*boostDaughterToParent );	
+	granddaughter2Daughter.Boost( -1.0*boostDaughterToParent );	
+
+
+	vector< TVector3 > locxyzH = getHelicityAxes(daughterParent3, z);
+	TVector3 xH = locxyzH[0];	
+	TVector3 yH = locxyzH[1];	
+	TVector3 zH = locxyzH[2];
+
+	TVector3 daughterDecayVector;
+	if( granddaughter2Lab.E() > 0) 
+		daughterDecayVector = ( granddaughter1Daughter.Vect() ).Cross( granddaughter2Daughter.Vect() );
+	else
+		daughterDecayVector = granddaughter1Daughter.Vect();
+
+	TVector3 anglesH( daughterDecayVector.Dot( xH ), 
+				daughterDecayVector.Dot( yH ), 
+				daughterDecayVector.Dot( zH ) );
+
+	double thetaH = anglesH.Theta();
+	double phiH = anglesH.Phi();	
+
+
+  	// compute omega dalitz decay variable lambda
+  	double m0 = 0.1349766;
+  	double mq = 0.1395702;
+  	double lambda_max = 3/4. * TMath::Power(1/9. * (5*daughterLab.M2() + 3*(m0*m0 - 4*mq*mq) - 4*sqrt(daughterLab.M2()*daughterLab.M2() + 3*daughterLab.M2()*(m0*m0-mq*mq))), 2); 
+  	double lambda = fabs( daughterDecayVector.Dot( daughterDecayVector ) ) / lambda_max;
+
+	vector< double > thetaPhiTwoStep{theta, phi, thetaH, phiH, lambda};
+
+	return thetaPhiTwoStep;
+}
+
+
+

--- a/src/libraries/AMPTOOLS_AMPS/decayAngles.h
+++ b/src/libraries/AMPTOOLS_AMPS/decayAngles.h
@@ -1,0 +1,24 @@
+
+#if !defined(DECAYANGLES)
+#define DECAYANGLES
+
+#include <string>
+#include <complex>
+#include <vector>
+
+#include "TLorentzVector.h"
+
+using std::complex;
+using namespace std;
+
+vector< TVector3 > getHelicityAxes(TVector3 parentCM, TVector3 inverseCM);
+
+vector< TVector3 > getGJAxes(TVector3 parentCM, TVector3 inverseCM, TVector3 inverseParent);
+
+double getPhiProd(double polAngle, TLorentzVector parentLab, TLorentzVector beamLab, TLorentzVector targetLab, int whichFrame, bool upperVertex);
+
+vector< double > getOneStepAngles(TLorentzVector parentLab, TLorentzVector daughterLab, TLorentzVector beamLab, TLorentzVector targetLab, int whichFrame, bool upperVertex = true);
+
+vector< double > getTwoStepAngles(TLorentzVector parentLab, TLorentzVector daughterLab, TLorentzVector granddaughter1Lab, TLorentzVector granddaughter2Lab, TLorentzVector beamLab, TLorentzVector targetLab, int whichFrame, bool upperVertex);
+
+#endif

--- a/src/libraries/AMPTOOLS_AMPS/wignerD.cc
+++ b/src/libraries/AMPTOOLS_AMPS/wignerD.cc
@@ -6,7 +6,7 @@ using namespace std;
 
 GDouble
 wignerDSmall( GDouble aj, GDouble am, GDouble an, GDouble beta ){
-  
+
 	// Calculates the beta-term
 	//                         d j mn (beta)
 	// in the matrix element of the finite rotation operator
@@ -15,9 +15,9 @@ wignerDSmall( GDouble aj, GDouble am, GDouble an, GDouble beta ){
 	// Quantum Theory of Angular Momentum, World Scientific,
 	// Singapore 1988.
 	// CERNLIB DDJMNB function translated from Fortran to C++ by Rene Brun
-  
+
 	double f = 8.72664625997164788e-3;    
-  
+
   double fcl[51] = { 0 , 0 ,
 		6.93147180559945309e-1 ,1.79175946922805500e00,
 		3.17805383034794562e00 ,4.78749174278204599e00,
@@ -48,10 +48,10 @@ wignerDSmall( GDouble aj, GDouble am, GDouble an, GDouble beta ){
 	int jpm = int(aj+am);
 	int jpn = int(aj+an);
 	int jmm = int(aj-am);	
-	
+
 	int jmn = int(aj-an);
 	int mpn = int(am+an);
-	
+
 	double r = 0;
 	if (beta == 0) 
 	{
@@ -95,25 +95,36 @@ wignerDSmall( GDouble aj, GDouble am, GDouble an, GDouble beta ){
 			q   = -q;
 		}
 	}
-  
+
 	return r;
 }
 
-
 complex< GDouble > wignerD( int l, int m, int n, 
                            GDouble cosTheta, GDouble phi ){
-	
+
     double dtheta = acos( cosTheta ) * 180.0 / PI;
-	
+
     GDouble dpart = wignerDSmall( l, m, n, dtheta );
-	
+
     return complex< GDouble >( cos( -1.0 * m * phi ) * dpart, 
 							sin( -1.0 * m * phi ) * dpart );
-	
+
+}
+
+complex< GDouble > wignerD( GDouble l, GDouble m, GDouble n,
+                           GDouble cosTheta, GDouble phi ){
+
+    double dtheta = acos( cosTheta ) * 180.0 / PI;
+
+    GDouble dpart = wignerDSmall( l, m, n, dtheta );
+
+    return complex< GDouble >( cos( -1.0 * m * phi ) * dpart,
+							sin( -1.0 * m * phi ) * dpart );
+
 }
 
 complex< GDouble > Y( int l, int m, GDouble cosTheta, GDouble phi ){
-  
+
   return ( (GDouble)sqrt( (2*l+1) / (4*PI) ) ) * 
           conj( wignerD( l, m, 0, cosTheta, phi ) );
 }

--- a/src/libraries/AMPTOOLS_AMPS/wignerD.h
+++ b/src/libraries/AMPTOOLS_AMPS/wignerD.h
@@ -8,6 +8,7 @@
 using std::complex;
 
 GDouble wignerDSmall( GDouble aj, GDouble am, GDouble an, GDouble beta );
+complex< GDouble > wignerD( GDouble l, GDouble m, GDouble n, GDouble cosTheta, GDouble phi );
 complex< GDouble > wignerD( int l, int m, int n, GDouble cosTheta, GDouble phi );
 complex< GDouble > Y( int l, int m, GDouble cosTheta, GDouble phi );
 

--- a/src/programs/AmplitudeAnalysis/fit/fit.cc
+++ b/src/programs/AmplitudeAnalysis/fit/fit.cc
@@ -45,6 +45,7 @@
 #include "AMPTOOLS_AMPS/ComplexCoeff.h"
 #include "AMPTOOLS_AMPS/OmegaDalitz.h"
 #include "AMPTOOLS_AMPS/Piecewise.h"
+#include "AMPTOOLS_AMPS/LowerVertexDelta.h"
 
 #include "MinuitInterface/MinuitMinimizationManager.h"
 #include "IUAmpTools/AmpToolsInterface.h"
@@ -335,6 +336,7 @@ int main( int argc, char* argv[] ){
    AmpToolsInterface::registerAmplitude( ComplexCoeff() );
    AmpToolsInterface::registerAmplitude( OmegaDalitz() );
    AmpToolsInterface::registerAmplitude( Piecewise() );
+   AmpToolsInterface::registerAmplitude( LowerVertexDelta() );
 
    AmpToolsInterface::registerDataReader( ROOTDataReader() );
    AmpToolsInterface::registerDataReader( ROOTDataReaderBootstrap() );

--- a/src/programs/AmplitudeAnalysis/fit/fit.cc
+++ b/src/programs/AmplitudeAnalysis/fit/fit.cc
@@ -46,6 +46,7 @@
 #include "AMPTOOLS_AMPS/OmegaDalitz.h"
 #include "AMPTOOLS_AMPS/Piecewise.h"
 #include "AMPTOOLS_AMPS/LowerVertexDelta.h"
+#include "AMPTOOLS_AMPS/SinglePS.h"
 
 #include "MinuitInterface/MinuitMinimizationManager.h"
 #include "IUAmpTools/AmpToolsInterface.h"
@@ -337,6 +338,7 @@ int main( int argc, char* argv[] ){
    AmpToolsInterface::registerAmplitude( OmegaDalitz() );
    AmpToolsInterface::registerAmplitude( Piecewise() );
    AmpToolsInterface::registerAmplitude( LowerVertexDelta() );
+   AmpToolsInterface::registerAmplitude( SinglePS() );
 
    AmpToolsInterface::registerDataReader( ROOTDataReader() );
    AmpToolsInterface::registerDataReader( ROOTDataReaderBootstrap() );

--- a/src/programs/AmplitudeAnalysis/fitMPI/fitMPI.cc
+++ b/src/programs/AmplitudeAnalysis/fitMPI/fitMPI.cc
@@ -43,6 +43,8 @@
 #include "AMPTOOLS_AMPS/PhaseOffset.h"
 #include "AMPTOOLS_AMPS/ComplexCoeff.h"
 #include "AMPTOOLS_AMPS/OmegaDalitz.h"
+#include "AMPTOOLS_AMPS/LowerVertexDelta.h"
+#include "AMPTOOLS_AMPS/SinglePS.h"
 
 #include "MinuitInterface/MinuitMinimizationManager.h"
 #include "IUAmpToolsMPI/AmpToolsInterfaceMPI.h"
@@ -378,6 +380,8 @@ int main( int argc, char* argv[] ){
    AmpToolsInterface::registerAmplitude( PhaseOffset() );
    AmpToolsInterface::registerAmplitude( ComplexCoeff() );
    AmpToolsInterface::registerAmplitude( OmegaDalitz() );
+   AmpToolsInterface::registerAmplitude( LowerVertexDelta() );
+   AmpToolsInterface::registerAmplitude( SinglePS() );
 
    AmpToolsInterface::registerDataReader( DataReaderMPI<ROOTDataReader>() );
    AmpToolsInterface::registerDataReader( DataReaderMPI<ROOTDataReaderBootstrap>() );

--- a/src/programs/Simulation/gen_amp/gen_amp.cc
+++ b/src/programs/Simulation/gen_amp/gen_amp.cc
@@ -38,6 +38,8 @@
 #include "AMPTOOLS_AMPS/Uniform.h"
 #include "AMPTOOLS_AMPS/ComplexCoeff.h"
 #include "AMPTOOLS_AMPS/OmegaDalitz.h"
+#include "AMPTOOLS_AMPS/LowerVertexDelta.h"
+#include "AMPTOOLS_AMPS/SinglePS.h"
 
 #include "AMPTOOLS_MCGEN/ProductionMechanism.h"
 #include "AMPTOOLS_MCGEN/GammaPToNPartP.h"
@@ -303,6 +305,8 @@ int main( int argc, char* argv[] ){
 	AmpToolsInterface::registerAmplitude( Uniform() );
 	AmpToolsInterface::registerAmplitude( ComplexCoeff() );
 	AmpToolsInterface::registerAmplitude( OmegaDalitz() );
+	AmpToolsInterface::registerAmplitude( LowerVertexDelta() );
+	AmpToolsInterface::registerAmplitude( SinglePS() );
 	AmpToolsInterface ati( cfgInfo, AmpToolsInterface::kMCGeneration );
 
 	// loop to look for beam configuration file

--- a/src/programs/Simulation/gen_omegapi/gen_omegapi.cc
+++ b/src/programs/Simulation/gen_omegapi/gen_omegapi.cc
@@ -26,6 +26,7 @@
 #include "AMPTOOLS_AMPS/OmegaDalitz.h"
 #include "AMPTOOLS_AMPS/PhaseOffset.h"
 #include "AMPTOOLS_AMPS/ComplexCoeff.h"
+#include "AMPTOOLS_AMPS/LowerVertexDelta.h"
 
 #include "AMPTOOLS_MCGEN/ProductionMechanism.h"
 #include "AMPTOOLS_MCGEN/GammaPToNPartP.h"
@@ -265,6 +266,7 @@ int main( int argc, char* argv[] ){
         AmpToolsInterface::registerAmplitude( OmegaDalitz() );
         AmpToolsInterface::registerAmplitude( PhaseOffset() );
 	AmpToolsInterface::registerAmplitude( ComplexCoeff() );
+	AmpToolsInterface::registerAmplitude( LowerVertexDelta() );
 
 	AmpToolsInterface ati( cfgInfo, AmpToolsInterface::kMCGeneration );
 


### PR DESCRIPTION
This PR creates a new amplitude class that models a Delta baryon decaying at the lower vertex of a reaction. This PR registers the amplitude with the programs `fit` and `gen_omegapi`, but other programs may also need to be told about it.

It also adds a utility class called `decayAngles`, which can calculate the angles involved in the decay of a particle in the helicity or GJ reference frame.

Finally, it changes the `wignerD` utility class, allowing it to accept fractional spin indices. I think this won't break anything, since the sums of any two indices are still required to be an integer, but it may need testing