### PR TITLE
Patch fit and fitMPI

### DIFF
--- a/src/programs/AmplitudeAnalysis/fit/fit.cc
+++ b/src/programs/AmplitudeAnalysis/fit/fit.cc
@@ -109,7 +109,7 @@ void runRndFits(ConfigurationInfo* cfgInfo, bool useMinos, bool hesse, int maxIt
   vector< vector<string> > parRangeKeywords = cfgInfo->userKeywordArguments("parRange");
 
   // keep track of best fit (mininum log-likelihood)
-  double minLL = std::numeric_limits<double>::max();
+  double minLL = numeric_limits<double>::max();
   int minFitTag = -1;
 
   for(int i=0; i<numRnd; i++) {

--- a/src/programs/AmplitudeAnalysis/fit/fit.cc
+++ b/src/programs/AmplitudeAnalysis/fit/fit.cc
@@ -6,6 +6,7 @@
 #include <vector>
 #include <utility>
 #include <map>
+#include <limits>
 
 #include "TSystem.h"
 
@@ -108,7 +109,7 @@ void runRndFits(ConfigurationInfo* cfgInfo, bool useMinos, bool hesse, int maxIt
   vector< vector<string> > parRangeKeywords = cfgInfo->userKeywordArguments("parRange");
 
   // keep track of best fit (mininum log-likelihood)
-  double minLL = 0;
+  double minLL = std::numeric_limits<double>::max();
   int minFitTag = -1;
 
   for(int i=0; i<numRnd; i++) {

--- a/src/programs/AmplitudeAnalysis/fitMPI/fitMPI.cc
+++ b/src/programs/AmplitudeAnalysis/fitMPI/fitMPI.cc
@@ -6,6 +6,7 @@
 #include <vector>
 #include <utility>
 #include <map>
+#include <limits>
 
 #include "TSystem.h"
 
@@ -119,7 +120,7 @@ void runRndFits(ConfigurationInfo* cfgInfo, bool useMinos, bool hesse, int maxIt
       parRangeKeywords = cfgInfo->userKeywordArguments("parRange");
 
       // keep track of best fit (mininum log-likelihood)
-      minLH = 0;
+      minLH = numeric_limits<double>::max();
       minFitTag = -1;
    }
 


### PR DESCRIPTION
The `runRndFits` method in `fit.cc` and `fitMPI.cc` take a set of fits and compare log-likelihoods to find the best. Currently, this is done by setting a variable `minLL = 0` and then looping over the fits to see if any of their log-likelihoods are less than `minLL`. However, the log-likelihood in an extended max-likelihood fit can sometimes be positive (for instance, if you use the accepted MC as the generated MC for testing or if you have a small amount of MC) since we ignore additive correction terms in the minimization. If all of the log-likelihoods of your fits turn out to be positive, then `runRndFits` will declare that "ALL FITS FAILED" even if they all successfully converged. This patch sets the initial value of `minLL` to `+inf` using the standard library `limits` header. This comparison happens outside the fits themselves, and just serves as an initial value to compare to—`minLL` is quickly set to the value of the first converged fit anyway.