### PR TITLE
change lab to CM for calculation of prodPhi

### DIFF
--- a/src/libraries/AMPTOOLS_AMPS/decayAngles.cc
+++ b/src/libraries/AMPTOOLS_AMPS/decayAngles.cc
@@ -83,7 +83,7 @@ double getPhiProd(double polAngle, TLorentzVector parentLab, TLorentzVector beam
 
 	TVector3 eps( cos( polAngle ), sin( polAngle ), 0.0 );
 
-	double phiProd = atan2( y.Dot( eps ), inverseLab.Vect().Unit().Dot( eps.Cross( y ) ) );
+	double phiProd = atan2( y.Dot( eps ), inverseCM.Vect().Unit().Dot( eps.Cross( y ) ) );
 
 	return phiProd;	
 } 


### PR DESCRIPTION
small change to fix production plane calculation for lower vertex. when target is used for z-axis reference need to boost to CM frame