### PR TITLE
avoid compiler warnings

### DIFF
--- a/src/libraries/AMPTOOLS_DATAIO/VecPsPlotGenerator.cc
+++ b/src/libraries/AMPTOOLS_DATAIO/VecPsPlotGenerator.cc
@@ -69,7 +69,9 @@ VecPsPlotGenerator::projectEvent( Kinematics* kin, const string& reactionName ){
    }
 
    TLorentzVector vec, vec_daught1, vec_daught2; // compute for each final state below 
-   double dalitz_s, dalitz_t, dalitz_u, dalitz_d, dalitz_sc, dalitzx, dalitzy; //initialize with 0?
+   double dalitz_s, dalitz_t, dalitz_u, dalitz_d, dalitz_sc;
+   double dalitzx = 0;
+   double dalitzy = 0;
 
    if(m_3pi) {
 	  // omega ps proton, omega -> 3pi (6 particles)
@@ -106,6 +108,8 @@ VecPsPlotGenerator::projectEvent( Kinematics* kin, const string& reactionName ){
           vec_daught2 = kin->particle( 4 );
           vec = vec_daught1 + vec_daught2;
 	  min_recoil = 5;
+	  dalitzx = 0.;
+	  dalitzy = 0.;
    }
 
    // final meson system P4

--- a/src/programs/AmplitudeAnalysis/omegapi_plotter/omegapi_plotter.cc
+++ b/src/programs/AmplitudeAnalysis/omegapi_plotter/omegapi_plotter.cc
@@ -73,7 +73,7 @@ int main( int argc, char* argv[] ){
     return 0;
   }
 
-  bool showGui = false;
+  // bool showGui = false;
   bool makePlots = true;
   string outName = "omegapi_plot.root";
   string resultsName(argv[1]);
@@ -81,9 +81,9 @@ int main( int argc, char* argv[] ){
 
     string arg(argv[i]);
 
-    if (arg == "-g"){
-      showGui = true;
-    }
+    // if (arg == "-g"){
+    //   showGui = true;
+    // }
     if (arg == "-o"){
       outName = argv[++i];
     }
@@ -93,7 +93,7 @@ int main( int argc, char* argv[] ){
     if (arg == "-h"){
       cout << endl << " Usage for: " << argv[0] << endl << endl;
       cout << "\t -o <file>\t output file path" << endl;
-      cout << "\t -g \t show GUI" << endl;
+      // cout << "\t -g \t show GUI" << endl;
       cout << "\t -n \t don't make plots "<< endl;
       exit(1);
     }

--- a/src/programs/Simulation/gen_ee/code/gen_ee.cc
+++ b/src/programs/Simulation/gen_ee/code/gen_ee.cc
@@ -162,7 +162,7 @@ int main(int argc, char **argv){
   
   TGraph * grXS_pair = new TGraph();
   TGraph * grXS_trip = new TGraph();
-  double Z = 0, A = 0, rho = 0, Ltarget = 0;
+  double Z = 0; //, A = 0, rho = 0, Ltarget = 0;
   // Get generator config file
   if (genSettings.genconfigfile != "") {
     MyReadConfig * ReadFile = new MyReadConfig();
@@ -176,9 +176,9 @@ int main(int argc, char **argv){
     TString m_XS_pair = ReadFile->GetConfigName("XS_pair"); 
     TString m_XS_trip = ReadFile->GetConfigName("XS_trip"); 
     Z = m_target[0];
-    A = m_target[1];
-    rho = m_target[2];
-    Ltarget = m_target[3];
+    // A = m_target[1];
+    // rho = m_target[2];
+    // Ltarget = m_target[3];
     grXS_pair = new TGraph(m_XS_pair);
     grXS_trip = new TGraph(m_XS_trip);
     genSettings.polDir = (int) m_polDir[0];

--- a/src/programs/Simulation/gen_primex_eta_he4/gen_primex_eta_he4.cc
+++ b/src/programs/Simulation/gen_primex_eta_he4/gen_primex_eta_he4.cc
@@ -193,7 +193,7 @@ int main( int argc, char* argv[] ){
   TString m_decay = ReadFile->GetConfigName("decay"); 
   TString m_target = ReadFile->GetConfigName("target"); 
   TString m_Fermi_file = ReadFile->GetConfigName("Fermi_file"); 
-  Double_t * m_binning = ReadFile->GetConfig6Par("binning");
+  // Double_t * m_binning = ReadFile->GetConfig6Par("binning");
   /*if (m_decay != 0) {
     bin_egam = (int) m_binning[0];
     egam_min = m_binning[1];
@@ -270,8 +270,8 @@ int main( int argc, char* argv[] ){
     TLorentzVector IS_4Vec = InGamma_4Vec + Target_4Vec;
     
     // Mass in the centre-of-mass frame
-    double sqrt_s = IS_4Vec.M();
-    double s = pow(sqrt_s, 2);
+    // double sqrt_s = IS_4Vec.M();
+    // double s = pow(sqrt_s, 2);
     
     // Histo. creation that will store the calculated diff. xs. vs. LAB polar angle
     int ebeam_bin = h_dxs->GetXaxis()->FindBin(ebeam);


### PR DESCRIPTION
only one remains:
```
libraries/AMPTOOLS_AMPS/Piecewise.cc: In member function ‘virtual void Piecewise::calcUserVars(GDouble**, GDouble*) const’:
libraries/AMPTOOLS_AMPS/Piecewise.cc:106:47: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
   userVars[uv_imassbin] = *((GDouble*)&tempBin);
```