### PR TITLE
  Update to timting resolution values

### DIFF
--- a/src/programs/Simulation/mcsmear/FCALSmearer.h
+++ b/src/programs/Simulation/mcsmear/FCALSmearer.h
@@ -29,7 +29,13 @@ class fcal_config_t
 	double INSERT_ENERGY_WIDTH_FLOOR;	
 	double FCAL_ENERGY_RANGE;
 	bool FCAL_ADD_LIGHTGUIDE_HITS;
-    double FCAL_LIGHTGUIDE_SCALE_FACTOR;
+    	double FCAL_LIGHTGUIDE_SCALE_FACTOR;
+	bool FCAL_NEW_TIME_SMEAR;
+ 	double FCAL_TIME_A;
+  	double FCAL_TIME_B;
+  	double FCAL_TIME_C;
+  	double FCAL_TIME_D;
+  	double FCAL_TIME_E;
 	
 	vector< vector<double > > block_efficiencies;
 	
@@ -50,6 +56,7 @@ class FCALSmearer : public Smearer
     fcal_config = new fcal_config_t(loop, fcalGeom);
     fcal_config->FCAL_ADD_LIGHTGUIDE_HITS = in_config->FCAL_ADD_LIGHTGUIDE_HITS;
     fcal_config->FCAL_LIGHTGUIDE_SCALE_FACTOR = in_config->FCAL_LIGHTGUIDE_SCALE_FACTOR;
+    fcal_config->FCAL_NEW_TIME_SMEAR = in_config->FCAL_NEW_TIME_SMEAR;
   }
   ~FCALSmearer() {
     delete fcal_config;

--- a/src/programs/Simulation/mcsmear/mcsmear.cc
+++ b/src/programs/Simulation/mcsmear/mcsmear.cc
@@ -107,6 +107,8 @@ void ParseCommandLineArguments(int narg, char* argv[], mcsmear_config_t *config)
           case 'E': config->FCAL_ADD_LIGHTGUIDE_HITS=false;       break;
 	      case 'R': config->SKIP_READING_RCDB=true;              break;
 	      case 't': config->MERGE_TAGGER_HITS=false;             break;
+	      case 'W': config->FCAL_NEW_TIME_SMEAR=true;            break;
+              case 'w': config->FCAL_NEW_TIME_SMEAR=false;           break;
 	      case 'l': {
 	   		config->DETECTORS_TO_LOAD=&ptr[2];
 	   		cout << "Detector list: " << config->DETECTORS_TO_LOAD << endl;  
@@ -229,6 +231,8 @@ void Usage(void)
  //  cout << "    -Xsigma  BCAL fADC time resolution (def. " << BCAL_FADC_TIME_RESOLUTION << " ns)" << endl;
    cout << "    -R       Don't load information from RCDB" << endl;
    cout << "    -t       Don't merge random hits from tagger counters" << endl;
+   cout << "    -W       Use new energy-dependent FCAL time smearing" << endl;
+   cout << "    -w       Use old energy-dependent FCAL time smearing (default)" << endl;
    cout << "    -D       Dump configuration debug information" << endl;
    cout << "    -E       Don't include FCAL light guide energy deposition (def. include)" << endl;
    cout << "    -G       Don't smear BCAL times (def. smear)" << endl;

--- a/src/programs/Simulation/mcsmear/mcsmear_config.cc
+++ b/src/programs/Simulation/mcsmear/mcsmear_config.cc
@@ -29,6 +29,7 @@ mcsmear_config_t::mcsmear_config_t()
 
 	FCAL_ADD_LIGHTGUIDE_HITS = true;
     FCAL_LIGHTGUIDE_SCALE_FACTOR = -1.;
+	FCAL_NEW_TIME_SMEAR = false;
 
 	SKIP_READING_RCDB = false;
 	MERGE_TAGGER_HITS = true;

--- a/src/programs/Simulation/mcsmear/mcsmear_config.h
+++ b/src/programs/Simulation/mcsmear/mcsmear_config.h
@@ -48,7 +48,6 @@ class mcsmear_config_t
     bool FCAL_ADD_LIGHTGUIDE_HITS;
     double FCAL_LIGHTGUIDE_SCALE_FACTOR;
 	
-	bool FCAL_ADD_LIGHTGUIDE_HITS;
 	bool FCAL_NEW_TIME_SMEAR;
 	// flags to pass command line info to subdetector classes
 	double BCAL_NO_T_SMEAR;

--- a/src/programs/Simulation/mcsmear/mcsmear_config.h
+++ b/src/programs/Simulation/mcsmear/mcsmear_config.h
@@ -48,6 +48,8 @@ class mcsmear_config_t
     bool FCAL_ADD_LIGHTGUIDE_HITS;
     double FCAL_LIGHTGUIDE_SCALE_FACTOR;
 	
+	bool FCAL_ADD_LIGHTGUIDE_HITS;
+	bool FCAL_NEW_TIME_SMEAR;
 	// flags to pass command line info to subdetector classes
 	double BCAL_NO_T_SMEAR;
 	double BCAL_NO_DARK_PULSES;


### PR DESCRIPTION
The update allows an option to use the original 0.4 ns timing resolution or use an energy dependent timing resolution where the parameters were measured from a timing resolution experiment. The timing resolution is used in mcsmear.