### PR TITLE
Fix bug where some FCAL mcsmear parameters were geting overwritten (again).

### DIFF
--- a/src/programs/Simulation/mcsmear/FCALSmearer.h
+++ b/src/programs/Simulation/mcsmear/FCALSmearer.h
@@ -54,8 +54,6 @@ class FCALSmearer : public Smearer
     loop->GetSingle(fcalGeom);
 
     fcal_config = new fcal_config_t(loop, fcalGeom, in_config);
-    fcal_config->FCAL_ADD_LIGHTGUIDE_HITS = in_config->FCAL_ADD_LIGHTGUIDE_HITS;
-    fcal_config->FCAL_LIGHTGUIDE_SCALE_FACTOR = in_config->FCAL_LIGHTGUIDE_SCALE_FACTOR;
     fcal_config->FCAL_NEW_TIME_SMEAR = in_config->FCAL_NEW_TIME_SMEAR;
     
   }


### PR DESCRIPTION
Some lines that were removed from #299 got readded in #298 (which was merged afterwards).

Seems like we need to be more carefully on the look out for these sort of merge problems.