### PR TITLE
added option to print amplitudes

### DIFF
--- a/src/programs/AmplitudeAnalysis/fit/fit.cc
+++ b/src/programs/AmplitudeAnalysis/fit/fit.cc
@@ -254,6 +254,19 @@ void getLikelihood( ConfigurationInfo* cfgInfo ){
     return;
 }
 
+void printAmplitudes( ConfigurationInfo* cfgInfo ){
+
+  AmpToolsInterface ati( cfgInfo, AmpToolsInterface::kPlotGeneration );
+  DataReader* dataReader = ati.dataReader(cfgInfo->reactionList()[0]->reactionName());  
+  dataReader->resetSource();
+  for (int i = 0; i < 2; i++){
+    Kinematics* kin = dataReader->getEvent();
+    ati.printEventDetails(cfgInfo->reactionList()[0]->reactionName(),kin);
+    delete kin;
+  }
+  return;
+}
+
 int main( int argc, char* argv[] ){
 
    // set default parameters
@@ -261,6 +274,7 @@ int main( int argc, char* argv[] ){
    bool useMinos = false;
    bool hesse = false;
    bool noFit = false;
+   bool printAmps = false;
 
    string configfile;
    string seedfile;
@@ -293,20 +307,22 @@ int main( int argc, char* argv[] ){
       if (arg == "-n") useMinos = true;
       if (arg == "-H") hesse = true;
       if (arg == "-l") noFit = true;
+      if (arg == "-test" ) printAmps = true;
       if (arg == "-p"){
          if ((i+1 == argc) || (argv[i+1][0] == '-')) arg = "-h";
          else  scanPar = argv[++i]; }
       if (arg == "-h"){
          cout << endl << " Usage for: " << argv[0] << endl << endl;
-         cout << "   -n \t\t\t\t\t use MINOS instead of MIGRAD" << endl;
-         cout << "   -H \t\t\t\t\t evaluate HESSE matrix after minimization" << endl;
-         cout << "   -c <file>\t\t\t\t config file" << endl;
-         cout << "   -s <output file>\t\t\t for seeding next fit based on this fit (optional)" << endl;
+         cout << "   -n \t\t\t\t use MINOS instead of MIGRAD" << endl;
+         cout << "   -H \t\t\t\t evaluate HESSE matrix after minimization" << endl;
+         cout << "   -c <file>\t\t\t config file" << endl;
+         cout << "   -s <output file>\t\t for seeding next fit based on this fit (optional)" << endl;
          cout << "   -r <int>\t\t\t Perform <int> fits each seeded with random parameters" << endl;
-            cout << "   -rs <int>\t\t\t Sets the random seed used by the random number generator for the fits with randomized initial parameters. If not set will use the time()" << endl;
-         cout << "   -p <parameter> \t\t\t\t Perform a scan of given parameter. Stepsize, min, max are to be set in cfg file" << endl;
+         cout << "   -rs <int>\t\t\t Sets the random seed used by the random number generator for the fits with randomized initial parameters. If not set will use the time()" << endl;
+         cout << "   -p <parameter> \t\t Perform a scan of given parameter. Stepsize, min, max are to be set in cfg file" << endl;
          cout << "   -m <int>\t\t\t Maximum number of fit iterations" << endl; 
          cout << "   -l \t\t\t\t Calculate likelihood and exit without running a fit" << endl; 
+	 cout << "   -test \t\t\t Print amplitude details for the first 2 data events" << endl;
          exit(1);}
    }
 
@@ -358,16 +374,18 @@ int main( int argc, char* argv[] ){
    AmpToolsInterface::registerDataReader( FSRootDataReader() );
 
    if(noFit)
-      getLikelihood(cfgInfo);
+     getLikelihood(cfgInfo);
+   else if(printAmps)
+     printAmplitudes(cfgInfo);
    else if(numRnd==0){
-      if(scanPar=="")
-         runSingleFit(cfgInfo, useMinos, hesse, maxIter, seedfile);
-      else
-         runParScan(cfgInfo, useMinos, hesse, maxIter, seedfile, scanPar);
+     if(scanPar=="")
+       runSingleFit(cfgInfo, useMinos, hesse, maxIter, seedfile);
+     else
+       runParScan(cfgInfo, useMinos, hesse, maxIter, seedfile, scanPar);
    } else {
-      cout << "Running " << numRnd << " fits with randomized parameters with seed=" << randomSeed << endl;
-      AmpToolsInterface::setRandomSeed(randomSeed);
-      runRndFits(cfgInfo, useMinos, hesse, maxIter, seedfile, numRnd, 0.5);
+     cout << "Running " << numRnd << " fits with randomized parameters with seed=" << randomSeed << endl;
+     AmpToolsInterface::setRandomSeed(randomSeed);
+     runRndFits(cfgInfo, useMinos, hesse, maxIter, seedfile, numRnd, 0.5);
    }
 
   return 0;


### PR DESCRIPTION
This provides an option to print out aspects of the amplitude calculation for a couple of events without running a fit.  Ideally things like this would be in different executables, but then each of these needs to have all the data readers and amplitudes registered, which is a bit of a burden.