### PR TITLE
* restore ability to do particle gun simulations, was broken

### DIFF
--- a/src/programs/Simulation/HDGeant/gukine.F
+++ b/src/programs/Simulation/HDGeant/gukine.F
@@ -113,6 +113,9 @@
 #include "backgrounds.inc"
 #include "cobrems.inc"
 *
+      integer beamgen_disable
+      common /internal_beamgen/beamgen_disable
+
       DIMENSION VERTEX(4),PLAB(5)
       DIMENSION RNDM(20)
 
@@ -256,7 +259,7 @@ c         print *, ngen,' background photons generated this event'
 *
 *              Try coherent bremsstrahlung beam generation next
 *
-      elseif (E.gt.0) then
+      elseif (beamgen_disable.eq.0) then
          call beamgen(0.)
          call storeInput(IDRUN,IDEVT,1);
 *

--- a/src/programs/Simulation/HDGeant/uginit.F
+++ b/src/programs/Simulation/HDGeant/uginit.F
@@ -205,6 +205,10 @@
       data spotX/0/
       data spotY/0/
 
+      integer beamgen_disable
+      common /internal_beamgen/beamgen_disable
+      data beamgen_disable/0/
+
       integer vertex_spec(20)
       common /vertexSpec/ vertex_spec
       data vertex_spec/20*0/
@@ -390,6 +394,7 @@ c        endif
 *             Get beam properties from ccdb if needed
 *
       if (beamE0.eq.0) then
+         beamgen_disable = 1;
          beamE0 = get_endpoint_energy(IDRUN);
          beamEpeak = get_peak_energy(IDRUN);
          beamEmin = beamE0 * 0.25;


### PR DESCRIPTION
  inadvertently by a recent mod that reads the electron beam energy
  for a simulated run from ccdb if the BEAM card is not specified
  in control.in, but that made it impossible to detect a missing
  BEAM card that is the way a user requests a particle gun sim. In
  this fix, I record the missing BEAM card in an explicit flag. [rtj]