### PR TITLE
* in case a particular event produces excessive hits in some detector

### DIFF
--- a/src/programs/Simulation/HDGeant/hitCCal.c
+++ b/src/programs/Simulation/HDGeant/hitCCal.c
@@ -218,7 +218,7 @@ void hitComptonEMcal (float xin[4], float xout[4],
       {
          fprintf(stderr,"HDGeant error in hitComptonEMcal: ");
          fprintf(stderr,"max hit count %d exceeded, truncating!\n",MAX_HITS);
-         exit(2);
+         //exit(2);
       }
    }
 }

--- a/src/programs/Simulation/HDGeant/hitFCal.c
+++ b/src/programs/Simulation/HDGeant/hitFCal.c
@@ -207,7 +207,7 @@ void hitForwardEMcal (float xin[4], float xout[4],
             {
                fprintf(stderr,"HDGeant error in hitforwardEMcal: ");
                fprintf(stderr,"max hit count %d exceeded, truncating!\n",MAX_HITS);
-               exit(2);
+               //exit(2);
             }
          }
       }
@@ -227,7 +227,7 @@ void hitForwardEMcal (float xin[4], float xout[4],
       {
          fprintf(stderr,"HDGeant error in hitforwardEMcal: ");
          fprintf(stderr,"max hit count %d exceeded, truncating!\n",MAX_HITS);
-         exit(2);
+         //exit(2);
       }
 
       return;
@@ -343,7 +343,7 @@ void hitForwardEMcal (float xin[4], float xout[4],
       {
          fprintf(stderr,"HDGeant error in hitforwardEMcal: ");
          fprintf(stderr,"max hit count %d exceeded, truncating!\n",MAX_HITS);
-         exit(2);
+         //exit(2);
       }
    }
 }

--- a/src/programs/Simulation/HDGeant/hitGCal.c
+++ b/src/programs/Simulation/HDGeant/hitGCal.c
@@ -141,7 +141,7 @@ void hitGapEMcal (float xin[4], float xout[4],
       {
          fprintf(stderr,"HDGeant error in hitgapEMcal: ");
          fprintf(stderr,"max hit count %d exceeded, truncating!\n",MAX_HITS);
-         exit(2);
+         //exit(2);
       }
    }
 }

--- a/src/programs/Simulation/HDGeant/hitPS.c
+++ b/src/programs/Simulation/HDGeant/hitPS.c
@@ -162,7 +162,7 @@ void hitPS(float xin[4], float xout[4],float pin[5], float pout[5], float dEsum,
       {
          fprintf(stderr,"HDGeant error in hitPS: ");
          fprintf(stderr,"max hit count %d exceeded, truncating!\n",MAX_HITS);
-         exit(2);
+         //exit(2);
       }
    }
 }

--- a/src/programs/Simulation/HDGeant/hitPSC.c
+++ b/src/programs/Simulation/HDGeant/hitPSC.c
@@ -160,7 +160,7 @@ void hitPSC(float xin[4], float xout[4],float pin[5], float pout[5], float dEsum
       {
          fprintf(stderr,"HDGeant error in hitPSC: ");
          fprintf(stderr,"max hit count %d exceeded, truncating!\n",MAX_HITS);
-         exit(2);
+         //exit(2);
       }
    }
 }

--- a/src/programs/Simulation/HDGeant/hitStart.c
+++ b/src/programs/Simulation/HDGeant/hitStart.c
@@ -383,7 +383,7 @@ void hitStartCntr (float xin[4], float xout[4],
       {
          fprintf(stderr,"HDGeant error in hitStart: ");
          fprintf(stderr,"max hit count %d exceeded, truncating!\n",MAX_HITS);
-         exit(2);
+         //exit(2);
       }
    }
 }

--- a/src/programs/Simulation/HDGeant/hitTPOL.c
+++ b/src/programs/Simulation/HDGeant/hitTPOL.c
@@ -158,7 +158,7 @@ void hitTPOL(float xin[4], float xout[4],float pin[5], float pout[5], float dEsu
       {
          fprintf(stderr,"HDGeant error in hitTPOL: ");
          fprintf(stderr,"max hit count %d exceeded, truncating!\n",MAX_HITS);
-         exit(2);
+         //exit(2);
       }
    }
 }


### PR DESCRIPTION
  subsystem, report the truncation warning, but do not abort the sim [rtj]