### PR TITLE
factorize breit wigner functions to provide method to calculate amp f…

### DIFF
--- a/src/libraries/AMPTOOLS_AMPS/BreitWigner.cc
+++ b/src/libraries/AMPTOOLS_AMPS/BreitWigner.cc
@@ -61,7 +61,13 @@ BreitWigner::calcAmplitude( GDouble** pKin ) const
   GDouble mass  = Ptot.M();
   GDouble mass1 = P1.M();
   GDouble mass2 = P2.M();
-  
+
+  return calcAmplitudeFromMasses( mass, mass1, mass2 );
+}
+
+complex< GDouble >
+BreitWigner::calcAmplitudeFromMasses( GDouble mass, GDouble mass1, GDouble mass2 ) const
+{
   // assert positive breakup momenta     
   GDouble q0 = fabs( breakupMomentum(m_mass0, mass1, mass2) );
   GDouble q  = fabs( breakupMomentum(mass,    mass1, mass2) );

--- a/src/libraries/AMPTOOLS_AMPS/BreitWigner.h
+++ b/src/libraries/AMPTOOLS_AMPS/BreitWigner.h
@@ -36,6 +36,7 @@ public:
 	string name() const { return "BreitWigner"; }
   
   complex< GDouble > calcAmplitude( GDouble** pKin ) const;
+  complex< GDouble > calcAmplitudeFromMasses( GDouble mass, GDouble mass1, GDouble mass2 ) const;
 	  
   void updatePar( const AmpParameter& par );
     

--- a/src/libraries/AMPTOOLS_AMPS/BreitWigner3body.cc
+++ b/src/libraries/AMPTOOLS_AMPS/BreitWigner3body.cc
@@ -53,7 +53,7 @@ BreitWigner3body::calcAmplitude( GDouble** pKin ) const
 }
 
 complex< GDouble >
-BreitWigner::calcAmplitudeFromMasses( GDouble mass ) const
+BreitWigner3body::calcAmplitudeFromMasses( GDouble mass ) const
 {
   // this first factor just gets normalization right for BW's that have
   // no additional s-dependence from orbital L

--- a/src/libraries/AMPTOOLS_AMPS/BreitWigner3body.cc
+++ b/src/libraries/AMPTOOLS_AMPS/BreitWigner3body.cc
@@ -48,7 +48,13 @@ BreitWigner3body::calcAmplitude( GDouble** pKin ) const
   
   GDouble width = m_width0;
   //GDouble width = m_width0;
-  
+
+  return calcAmplitudeFromMasses( mass );
+}
+
+complex< GDouble >
+BreitWigner::calcAmplitudeFromMasses( GDouble mass ) const
+{
   // this first factor just gets normalization right for BW's that have
   // no additional s-dependence from orbital L
   complex<GDouble> bwtop( sqrt( m_mass0 * m_width0 / 3.1416 ), 0.0 );

--- a/src/libraries/AMPTOOLS_AMPS/BreitWigner3body.cc
+++ b/src/libraries/AMPTOOLS_AMPS/BreitWigner3body.cc
@@ -46,15 +46,14 @@ BreitWigner3body::calcAmplitude( GDouble** pKin ) const
   
   GDouble mass  = Ptot.M();
   
-  GDouble width = m_width0;
-  //GDouble width = m_width0;
-
   return calcAmplitudeFromMasses( mass );
 }
 
 complex< GDouble >
 BreitWigner3body::calcAmplitudeFromMasses( GDouble mass ) const
 {
+  GDouble width = m_width0;
+
   // this first factor just gets normalization right for BW's that have
   // no additional s-dependence from orbital L
   complex<GDouble> bwtop( sqrt( m_mass0 * m_width0 / 3.1416 ), 0.0 );

--- a/src/libraries/AMPTOOLS_AMPS/BreitWigner3body.h
+++ b/src/libraries/AMPTOOLS_AMPS/BreitWigner3body.h
@@ -36,6 +36,7 @@ public:
 	string name() const { return "BreitWigner3body"; }
   
   complex< GDouble > calcAmplitude( GDouble** pKin ) const;
+  complex< GDouble > calcAmplitudeFromMasses( GDouble mass ) const;
 	  
   void updatePar( const AmpParameter& par );
     


### PR DESCRIPTION
The overall goal is to factorize the computation a bit so that we have access to the amplitude as a function of masses instead of 4-vectors.

The current use case for this is to be able to extract the BW amplitude's complex contribution so that we can compare the **binned** moments (calculated from the partial waves) to the moments directly calculated from the data. 

I compiled `BreitWigner` locally and loaded it with my python wrapper. I thought I should make this modification for `BreitWigner3body` also, so I did.

Please squash this commit as there are some stupid minor errors I made

```
mass0 = "1.32"
width0 = "0.1"
orbitaL = "2"
daughter1 = "0" # shouldn't matter
daughter2 = "1" # shouldn't matter
args = [mass0, width0, orbitaL, daughter1, daughter2]
bw = BreitWigner(args)

meas_mass0 = 1.32
meas_mass1 = 0.135
meas_mass2 = 0.545
amplitude = bw.calcAmplitudeFromMasses(meas_mass0, meas_mass1, meas_mass2)

print(amplitude) # returns (-0+4.472672532485287j) which makes sense. Amplitude at peak is purely imaginary
```