### PR TITLE
Change energy from MeV to GeV

### DIFF
--- a/src/programs/Simulation/mcsmear/ECALSmearer.cc
+++ b/src/programs/Simulation/mcsmear/ECALSmearer.cc
@@ -119,7 +119,7 @@ void ECALSmearer::SmearEvent(hddm_s::HDDM *record){
 
       //         if (E > ecal_config->ECAL_BLOCK_THRESHOLD) {
       hddm_s::EcalHitList hits = iter->addEcalHits();
-      hits().setE(E*1000.);
+      hits().setE(E);
       hits().setT(t);
       //         }
     }


### PR DESCRIPTION
Change energy reported by mcsmear from MeV to GeV (MeV was used in the CCAL reconstruction)