### PR TITLE
Add K-matrix amplitudes from Kopf et al.

### DIFF
--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixA0.cc
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixA0.cc
@@ -1,0 +1,237 @@
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <complex>
+#include <cstdlib>
+#include <math.h>
+
+#include "TLorentzVector.h"
+
+#include "IUAmpTools/Kinematics.h"
+
+#include "AMPTOOLS_AMPS/barrierFactor.h"
+#include "AMPTOOLS_AMPS/breakupMomentum.h"
+#include "AMPTOOLS_AMPS/KopfKMatrixA0.h"
+
+/* 
+ *  Usage: KopfKMatrixA0 <daughter 1> <daughter 2> <channel> <Re[a₀(980)]> <Im[a₀(980)]> ...
+ * 
+ *  Parameters:
+ *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
+ *     the first decay product in the kinematic arrays. Note that this array typically starts
+ *     with the beam in location 0, so these values could be considered to be 1-indexed. If
+ *     the number is more than one digit long, each single digit will represent a particle
+ *     which, when added together, form the first decay product (e.g. 23 would sum particles
+ *     2 and 3 to make a new state).
+ *  2. <daughter 2>: Same as (1) but for the second decay product.
+ *  3. <channel>: A single digit corresponding to the final state channel (see table).
+ *     ╭────┬────╮
+ *     │ 0  │ 1  │
+ *     ├────┼────┤
+ *     │ ηπ │ KK̅ │
+ *     ╰────┴────╯
+ *  4. a₀(980) initial state coupling (real part)
+ *  5. a₀(980) initial state coupling (imaginary part)
+ *  6. a₀(1450) initial state coupling (real part)
+ *  7. a₀(1450) initial state coupling (imaginary part)
+ *
+ *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
+ */
+
+KopfKmatrixA0::KopfKmatrixA0(const vector<string> &args): UserAmplitude<KopfKmatrixA0>(args) {
+	assert(args.size() == 7);
+	m_daughters = pair<string, string>(args[0], args[1]);
+	channel = atoi(args[2].c_str());
+	ba0980_re = AmpParameter(args[3]);
+	ba0980_im = AmpParameter(args[4]);
+    ba01450_re = AmpParameter(args[5]);
+    ba01450_im = AmpParameter(args[6]);
+    registerParameter(ba0980_re);
+    registerParameter(ba0980_im);
+    registerParameter(ba01450_re);
+    registerParameter(ba01450_im);
+    ga0980 = SVector2(0.43215, -0.28825);
+    ga01450 = SVector2(0.19000, 0.43372);
+    masses = {0.95395, 1.26767};
+    couplings = {ga0980, ga01450};
+    m1s = {0.1349768, 0.493677};
+    m2s = {0.547862, 0.497611};
+    a_bkg = {
+        0.00000,
+        0.00000, 0.00000};
+    mat_bkg = SMatrix2Sym(a_bkg.begin(), a_bkg.end());
+}
+
+void KopfKmatrixA0::calcUserVars(GDouble** pKin, GDouble* userVars) const {
+    TLorentzVector pTemp, pTot;
+    /* This allows us to input something like
+     * "12 34" for the daughter particle parameters
+     * to indicate that the first daughter is the
+     * sum of the final state particles indexed
+     * 1 and 2 and the second daughter is created
+     * from the sum of 3 and 4
+     */
+    for(unsigned int i=0; i < m_daughters.first.size(); ++i) {
+        string num; num += m_daughters.first[i];
+        int index = atoi(num.c_str());
+        pTemp.SetPxPyPzE(pKin[index][1],
+                         pKin[index][2],
+                         pKin[index][3],
+                         pKin[index][0]);
+        pTot += pTemp;
+    }
+    for(unsigned int i=0; i < m_daughters.second.size(); ++i) {
+        string num; num += m_daughters.second[i];
+        int index = atoi(num.c_str());
+        pTemp.SetPxPyPzE(pKin[index][1],
+                         pKin[index][2],
+                         pKin[index][3],
+                         pKin[index][0]);
+        pTot += pTemp;
+    }
+    // Grab our hypothesis mass
+    GDouble m = pTot.M();
+    userVars[kM] = m;
+    GDouble s = pTot.M2();
+    userVars[kS] = s;
+    // Calculate K-Matrix
+    SMatrix2 mat_K; // Initialized as a 4x4 0-matrix
+    SMatrix2 mat_C;
+    // Loop over resonances
+    for (int i = 0; i < 2; i++) {
+        SMatrix2 temp_K;
+        SMatrix2 temp_B;
+        temp_K = TensorProd(couplings[i], couplings[i]);
+        temp_K += (mat_bkg * (masses[i] * masses[i] - s));
+        temp_K *= KopfKmatrixA0::poleProductRemainder(s, i);
+        // Loop over channels: 
+        SVector2 B_factor;
+        for (int j = 0; j < 2; j++) {
+            GDouble q_alpha = fabs(breakupMomentum(masses[i], m1s[j], m2s[j]));
+            GDouble q = fabs(breakupMomentum(m, m1s[j], m2s[j]));
+            GDouble B_num = barrierFactor(q, 0);
+            GDouble B_den = barrierFactor(q_alpha, 0);
+            B_factor[j] = B_num / B_den;
+        }
+        temp_B = TensorProd(B_factor, B_factor); 
+        // Loop over channels: 
+        for (int k = 0; k < 2; k++) {
+            // Loop over channels: 
+            for (int l = 0; l < 2; l++) {
+                temp_K(k, l) = temp_K(k, l) * temp_B(k, l); // element-wise multiplication
+            }
+        }
+        mat_K += temp_K;
+    }
+    // Loop over channels
+    for (int j = 0; j < 2; j++) {
+        mat_C(j, j) = KopfKmatrixA0::chew(s, m1s[j], m2s[j]);
+    }
+    SMatrix2 temp;
+    complex<GDouble> product = KopfKmatrixA0::poleProduct(s);
+    for (int i = 0; i < 2; ++i) {
+        temp(i, i) = product;
+    }
+    mat_K *= mat_C;
+    temp += mat_K;
+    // Now temp is (I + KC)
+    SMatrix2 temp_inv = KopfKmatrixA0::inverse2(temp); // (I + KC)^{-1}
+    // Now we cache the results
+    for (int i = 0; i < 2; i++) {
+        userVars[i + 2] = temp_inv(channel, i).real(); // +2 because kM and kS are first in the enum
+        userVars[i + 2 + 2] = temp_inv(channel, i).imag(); // +2 to skip the real parts 
+    }
+}
+
+
+
+complex<GDouble> KopfKmatrixA0::calcAmplitude(GDouble** pKin, GDouble* userVars) const {
+    GDouble m = userVars[kM]; 
+    GDouble s = userVars[kS];
+    SVector2 vec_P;
+    vector<complex<GDouble>> betas{
+        complex<GDouble>(ba0980_re, ba0980_im),
+        complex<GDouble>(ba01450_re, ba01450_im),
+    };
+    // Loop over resonances
+    for (int i = 0; i < 2; i++) {
+        SVector2 temp_P;
+        SMatrix2 temp_B;
+        temp_P = couplings[i];
+        temp_P *= betas[i]; 
+        temp_P *= KopfKmatrixA0::poleProductRemainder(s, i);
+        SVector2 B_factor;
+        // Loop over channels:
+        for (int j = 0; j < 2; j++) {
+            GDouble q_alpha = fabs(breakupMomentum(masses[i], m1s[j], m2s[j]));
+            GDouble q = fabs(breakupMomentum(m, m1s[j], m2s[j]));
+            GDouble B_num = barrierFactor(q, 0);
+            GDouble B_den = barrierFactor(q_alpha, 0);
+            B_factor[j] = B_num / B_den;
+        }
+        temp_B = TensorProd(B_factor, B_factor); 
+        temp_P = temp_P * B_factor;
+        vec_P += temp_P;
+    }
+    SVector2 temp_inv;
+    // Loop over channels:
+    for (int i = 0; i < 2; i++) {
+        temp_inv(i) = complex<GDouble>(userVars[i + 2], userVars[i + 2 + 2]);
+    }
+    return Dot(temp_inv, vec_P);
+}
+
+SMatrix2 KopfKmatrixA0::inverse2(SMatrix2 A) const {
+    // A matrix inverse that works for complex values
+    SMatrix2 M;
+    SMatrix2 I = SMatrixIdentity();
+    SMatrix2 temp;
+    complex<GDouble> c = 1;
+    for (int k = 1; k <= 2; k++) {
+        M = A * M + I * c;
+        temp = A * M;
+        c = temp.Trace() / (-1.0 * k);
+    }
+    return M / (-1.0 * c);
+}
+
+complex<GDouble> KopfKmatrixA0::rho(double s, double m1, double m2) const {
+    return sqrt(complex<GDouble>(((1 - ((m1 + m2) * (m1 + m2) / s)) * (1 - ((m1 - m2) * (m1 - m2) / s))), 0));
+}
+
+complex<GDouble> KopfKmatrixA0::xi(double s, double m1, double m2) const {
+    return complex<GDouble>(1 - ((m1 + m2) * (m1 + m2) / s), 0);
+}
+
+complex<GDouble> KopfKmatrixA0::chew(double s, double m1, double m2) const {
+    // The Chew-Mandelstam matrix as described by Appendix B in <https://doi.org/10.1103/PhysRevD.91.054008>
+    complex<GDouble> tot = 0;
+    tot += (KopfKmatrixA0::rho(s, m1, m2) / Pi()) * log((KopfKmatrixA0::xi(s, m1, m2) + KopfKmatrixA0::rho(s, m1, m2)) / (KopfKmatrixA0::xi(s, m1, m2) - KopfKmatrixA0::rho(s, m1, m2)));
+    tot -= (KopfKmatrixA0::xi(s, m1, m2) / Pi()) * ((m2 - m1) / (m1 + m2)) * log(m2 / m1);
+    return tot;
+}
+
+complex<GDouble> KopfKmatrixA0::poleProduct(double s) const {
+    // We multiply the numerator and denominator by the product of poles to remove
+    // division by zero errors when the measured mass is computationally close to
+    // the pole mass.
+    complex<GDouble> tot = 1;
+    for (size_t i = 0; i < masses.size(); ++i) {
+        tot *= complex<GDouble>(masses[i] * masses[i] - s);
+    }
+    return tot;
+}
+
+complex<GDouble> KopfKmatrixA0::poleProductRemainder(double s, size_t index) const {
+    // We multiply the numerator and denominator by the product of poles to remove
+    // division by zero errors when the measured mass is computationally close to
+    // the pole mass.
+    complex<GDouble> tot = 1;
+    for (size_t i = 0; i < masses.size(); ++i) {
+        if (i == index) continue;
+        tot *= complex<GDouble>(masses[i] * masses[i] - s);
+    }
+    return tot;
+}
+
+void KopfKmatrixA0::updatePar(const AmpParameter &par) {}

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixA0.cc
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixA0.cc
@@ -14,7 +14,7 @@
 #include "AMPTOOLS_AMPS/KopfKMatrixA0.h"
 
 /* 
- *  Usage: KopfKMatrixA0 <daughter 1> <daughter 2> <channel> <Re[a₀(980)]> <Im[a₀(980)]> ...
+ *  Usage: KopfKMatrixA0 <daughter 1> <daughter 2> <channel> <Re[a0(980)]> <Im[a0(980)]> ...
  * 
  *  Parameters:
  *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
@@ -24,16 +24,13 @@
  *     which, when added together, form the first decay product (e.g. 23 would sum particles
  *     2 and 3 to make a new state).
  *  2. <daughter 2>: Same as (1) but for the second decay product.
- *  3. <channel>: A single digit corresponding to the final state channel (see table).
- *     ╭────┬────╮
- *     │ 0  │ 1  │
- *     ├────┼────┤
- *     │ ηπ │ KK̅ │
- *     ╰────┴────╯
- *  4. a₀(980) initial state coupling (real part)
- *  5. a₀(980) initial state coupling (imaginary part)
- *  6. a₀(1450) initial state coupling (real part)
- *  7. a₀(1450) initial state coupling (imaginary part)
+ *  3. <channel>: A single digit corresponding to the final state channel:
+ *     0: pi-eta
+ *     1: K-Kbar
+ *  4. a0(980) initial state coupling (real part)
+ *  5. a0(980) initial state coupling (imaginary part)
+ *  6. a0(1450) initial state coupling (real part)
+ *  7. a0(1450) initial state coupling (imaginary part)
  *
  *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
  */

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixA0.cc
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixA0.cc
@@ -38,7 +38,7 @@
  *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
  */
 
-KopfKmatrixA0::KopfKmatrixA0(const vector<string> &args): UserAmplitude<KopfKmatrixA0>(args) {
+KopfKMatrixA0::KopfKMatrixA0(const vector<string> &args): UserAmplitude<KopfKMatrixA0>(args) {
 	assert(args.size() == 7);
 	m_daughters = pair<string, string>(args[0], args[1]);
 	channel = atoi(args[2].c_str());
@@ -62,7 +62,7 @@ KopfKmatrixA0::KopfKmatrixA0(const vector<string> &args): UserAmplitude<KopfKmat
     mat_bkg = SMatrix2Sym(a_bkg.begin(), a_bkg.end());
 }
 
-void KopfKmatrixA0::calcUserVars(GDouble** pKin, GDouble* userVars) const {
+void KopfKMatrixA0::calcUserVars(GDouble** pKin, GDouble* userVars) const {
     TLorentzVector pTemp, pTot;
     /* This allows us to input something like
      * "12 34" for the daughter particle parameters
@@ -103,7 +103,7 @@ void KopfKmatrixA0::calcUserVars(GDouble** pKin, GDouble* userVars) const {
         SMatrix2 temp_B;
         temp_K = TensorProd(couplings[i], couplings[i]);
         temp_K += (mat_bkg * (masses[i] * masses[i] - s));
-        temp_K *= KopfKmatrixA0::poleProductRemainder(s, i);
+        temp_K *= KopfKMatrixA0::poleProductRemainder(s, i);
         // Loop over channels: 
         SVector2 B_factor;
         for (int j = 0; j < 2; j++) {
@@ -125,17 +125,17 @@ void KopfKmatrixA0::calcUserVars(GDouble** pKin, GDouble* userVars) const {
     }
     // Loop over channels
     for (int j = 0; j < 2; j++) {
-        mat_C(j, j) = KopfKmatrixA0::chew(s, m1s[j], m2s[j]);
+        mat_C(j, j) = KopfKMatrixA0::chew(s, m1s[j], m2s[j]);
     }
     SMatrix2 temp;
-    complex<GDouble> product = KopfKmatrixA0::poleProduct(s);
+    complex<GDouble> product = KopfKMatrixA0::poleProduct(s);
     for (int i = 0; i < 2; ++i) {
         temp(i, i) = product;
     }
     mat_K *= mat_C;
     temp += mat_K;
     // Now temp is (I + KC)
-    SMatrix2 temp_inv = KopfKmatrixA0::inverse2(temp); // (I + KC)^{-1}
+    SMatrix2 temp_inv = KopfKMatrixA0::inverse2(temp); // (I + KC)^{-1}
     // Now we cache the results
     for (int i = 0; i < 2; i++) {
         userVars[i + 2] = temp_inv(channel, i).real(); // +2 because kM and kS are first in the enum
@@ -145,7 +145,7 @@ void KopfKmatrixA0::calcUserVars(GDouble** pKin, GDouble* userVars) const {
 
 
 
-complex<GDouble> KopfKmatrixA0::calcAmplitude(GDouble** pKin, GDouble* userVars) const {
+complex<GDouble> KopfKMatrixA0::calcAmplitude(GDouble** pKin, GDouble* userVars) const {
     GDouble m = userVars[kM]; 
     GDouble s = userVars[kS];
     SVector2 vec_P;
@@ -159,7 +159,7 @@ complex<GDouble> KopfKmatrixA0::calcAmplitude(GDouble** pKin, GDouble* userVars)
         SMatrix2 temp_B;
         temp_P = couplings[i];
         temp_P *= betas[i]; 
-        temp_P *= KopfKmatrixA0::poleProductRemainder(s, i);
+        temp_P *= KopfKMatrixA0::poleProductRemainder(s, i);
         SVector2 B_factor;
         // Loop over channels:
         for (int j = 0; j < 2; j++) {
@@ -181,7 +181,7 @@ complex<GDouble> KopfKmatrixA0::calcAmplitude(GDouble** pKin, GDouble* userVars)
     return Dot(temp_inv, vec_P);
 }
 
-SMatrix2 KopfKmatrixA0::inverse2(SMatrix2 A) const {
+SMatrix2 KopfKMatrixA0::inverse2(SMatrix2 A) const {
     // A matrix inverse that works for complex values
     SMatrix2 M;
     SMatrix2 I = SMatrixIdentity();
@@ -195,23 +195,23 @@ SMatrix2 KopfKmatrixA0::inverse2(SMatrix2 A) const {
     return M / (-1.0 * c);
 }
 
-complex<GDouble> KopfKmatrixA0::rho(double s, double m1, double m2) const {
+complex<GDouble> KopfKMatrixA0::rho(double s, double m1, double m2) const {
     return sqrt(complex<GDouble>(((1 - ((m1 + m2) * (m1 + m2) / s)) * (1 - ((m1 - m2) * (m1 - m2) / s))), 0));
 }
 
-complex<GDouble> KopfKmatrixA0::xi(double s, double m1, double m2) const {
+complex<GDouble> KopfKMatrixA0::xi(double s, double m1, double m2) const {
     return complex<GDouble>(1 - ((m1 + m2) * (m1 + m2) / s), 0);
 }
 
-complex<GDouble> KopfKmatrixA0::chew(double s, double m1, double m2) const {
+complex<GDouble> KopfKMatrixA0::chew(double s, double m1, double m2) const {
     // The Chew-Mandelstam matrix as described by Appendix B in <https://doi.org/10.1103/PhysRevD.91.054008>
     complex<GDouble> tot = 0;
-    tot += (KopfKmatrixA0::rho(s, m1, m2) / Pi()) * log((KopfKmatrixA0::xi(s, m1, m2) + KopfKmatrixA0::rho(s, m1, m2)) / (KopfKmatrixA0::xi(s, m1, m2) - KopfKmatrixA0::rho(s, m1, m2)));
-    tot -= (KopfKmatrixA0::xi(s, m1, m2) / Pi()) * ((m2 - m1) / (m1 + m2)) * log(m2 / m1);
+    tot += (KopfKMatrixA0::rho(s, m1, m2) / Pi()) * log((KopfKMatrixA0::xi(s, m1, m2) + KopfKMatrixA0::rho(s, m1, m2)) / (KopfKMatrixA0::xi(s, m1, m2) - KopfKMatrixA0::rho(s, m1, m2)));
+    tot -= (KopfKMatrixA0::xi(s, m1, m2) / Pi()) * ((m2 - m1) / (m1 + m2)) * log(m2 / m1);
     return tot;
 }
 
-complex<GDouble> KopfKmatrixA0::poleProduct(double s) const {
+complex<GDouble> KopfKMatrixA0::poleProduct(double s) const {
     // We multiply the numerator and denominator by the product of poles to remove
     // division by zero errors when the measured mass is computationally close to
     // the pole mass.
@@ -222,7 +222,7 @@ complex<GDouble> KopfKmatrixA0::poleProduct(double s) const {
     return tot;
 }
 
-complex<GDouble> KopfKmatrixA0::poleProductRemainder(double s, size_t index) const {
+complex<GDouble> KopfKMatrixA0::poleProductRemainder(double s, size_t index) const {
     // We multiply the numerator and denominator by the product of poles to remove
     // division by zero errors when the measured mass is computationally close to
     // the pole mass.
@@ -234,4 +234,4 @@ complex<GDouble> KopfKmatrixA0::poleProductRemainder(double s, size_t index) con
     return tot;
 }
 
-void KopfKmatrixA0::updatePar(const AmpParameter &par) {}
+void KopfKMatrixA0::updatePar(const AmpParameter &par) {}

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixA0.h
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixA0.h
@@ -1,0 +1,95 @@
+#if !defined(KOPFKMATRIXA0)
+#define KOPFKMATRIXA0
+
+#include "IUAmpTools/Amplitude.h"
+#include "IUAmpTools/AmpParameter.h"
+#include "IUAmpTools/UserAmplitude.h"
+#include "GPUManager/GPUCustomTypes.h"
+
+#include "Math/SVector.h"
+#include "Math/SMatrix.h"
+
+#include <utility>
+#include <string>
+#include <complex>
+#include <vector>
+
+using std::complex;
+using namespace std;
+using namespace ROOT::Math;
+typedef SMatrix<complex<GDouble>, 2> SMatrix2;
+typedef SMatrix<complex<GDouble>, 2, 2, ROOT::Math::MatRepSym<complex<GDouble>, 2>> SMatrix2Sym;
+typedef SVector<complex<GDouble>, 2> SVector2;
+
+/* 
+ *  Usage: KopfKMatrixA0 <daughter 1> <daughter 2> <channel> <Re[a₀(980)]> <Im[a₀(980)]> ...
+ * 
+ *  Parameters:
+ *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
+ *     the first decay product in the kinematic arrays. Note that this array typically starts
+ *     with the beam in location 0, so these values could be considered to be 1-indexed. If
+ *     the number is more than one digit long, each single digit will represent a particle
+ *     which, when added together, form the first decay product (e.g. 23 would sum particles
+ *     2 and 3 to make a new state).
+ *  2. <daughter 2>: Same as (1) but for the second decay product.
+ *  3. <channel>: A single digit corresponding to the final state channel (see table).
+ *     ╭────┬────╮
+ *     │ 0  │ 1  │
+ *     ├────┼────┤
+ *     │ ηπ │ KK̅ │
+ *     ╰────┴────╯
+ *  4. a₀(980) initial state coupling (real part)
+ *  5. a₀(980) initial state coupling (imaginary part)
+ *  6. a₀(1450) initial state coupling (real part)
+ *  7. a₀(1450) initial state coupling (imaginary part)
+ *
+ *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
+ */
+
+class Kinematics;
+
+class KopfKMatrixA0: public UserAmplitude<KopfKMatrixA0> {
+    public:
+        KopfKMatrixA0(): UserAmplitude<KopfKMatrixA0>() {}
+        KopfKMatrixA0(const vector<string> &args);
+	    enum UserVars {kM = 0, kS,
+            k0re, k1re,
+            k0im, k1im,
+            kNumUserVars};
+        unsigned int numUserVars() const {return kNumUserVars;}
+        void calcUserVars(GDouble** pKin, GDouble* userVars) const;
+        bool needsUserVarsOnly() const {return true;}
+        bool areUserVarsStatic() const {return true;}
+
+        ~KopfKMatrixA0(){}
+    
+        string name() const {return "KopfKMatrixA0";}
+
+        complex<GDouble> calcAmplitude(GDouble** pKin, GDouble* userVars) const;
+        void updatePar(const AmpParameter &par);
+
+    private:
+        pair<string, string> m_daughters;
+        int channel;
+        AmpParameter ba0980_re;
+        AmpParameter ba0980_im;
+        AmpParameter ba01450_re;
+        AmpParameter ba01450_im;
+
+        SVector2 ga0980;
+        SVector2 ga01450;
+        vector<SVector2> couplings;
+        vector<GDouble> masses;
+        vector<GDouble> m1s;
+        vector<GDouble> m2s;
+        vector<GDouble> a_bkg;
+        SMatrix2 mat_bkg;
+
+        SMatrix2 inverse2(SMatrix2 mat) const;
+        complex<GDouble> rho(double s, double m1, double m2) const;
+        complex<GDouble> xi(double s, double m1, double m2) const;
+        complex<GDouble> chew(double s, double m1, double m2) const;
+        complex<GDouble> poleProduct(double s) const;
+        complex<GDouble> poleProductRemainder(double s, size_t index) const;
+};
+#endif

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixA0.h
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixA0.h
@@ -22,7 +22,7 @@ typedef SMatrix<complex<GDouble>, 2, 2, ROOT::Math::MatRepSym<complex<GDouble>, 
 typedef SVector<complex<GDouble>, 2> SVector2;
 
 /* 
- *  Usage: KopfKMatrixA0 <daughter 1> <daughter 2> <channel> <Re[a₀(980)]> <Im[a₀(980)]> ...
+ *  Usage: KopfKMatrixA0 <daughter 1> <daughter 2> <channel> <Re[a0(980)]> <Im[a0(980)]> ...
  * 
  *  Parameters:
  *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
@@ -32,16 +32,13 @@ typedef SVector<complex<GDouble>, 2> SVector2;
  *     which, when added together, form the first decay product (e.g. 23 would sum particles
  *     2 and 3 to make a new state).
  *  2. <daughter 2>: Same as (1) but for the second decay product.
- *  3. <channel>: A single digit corresponding to the final state channel (see table).
- *     ╭────┬────╮
- *     │ 0  │ 1  │
- *     ├────┼────┤
- *     │ ηπ │ KK̅ │
- *     ╰────┴────╯
- *  4. a₀(980) initial state coupling (real part)
- *  5. a₀(980) initial state coupling (imaginary part)
- *  6. a₀(1450) initial state coupling (real part)
- *  7. a₀(1450) initial state coupling (imaginary part)
+ *  3. <channel>: A single digit corresponding to the final state channel:
+ *     0: pi-eta
+ *     1: K-Kbar
+ *  4. a0(980) initial state coupling (real part)
+ *  5. a0(980) initial state coupling (imaginary part)
+ *  6. a0(1450) initial state coupling (real part)
+ *  7. a0(1450) initial state coupling (imaginary part)
  *
  *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
  */

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixA2.cc
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixA2.cc
@@ -14,7 +14,7 @@
 #include "AMPTOOLS_AMPS/KopfKMatrixA2.h"
 
 /* 
- *  Usage: KopfKMatrixA2 <daughter 1> <daughter 2> <channel> <Re[a₂(1320)]> <Im[a₂(1320)]> ...
+ *  Usage: KopfKMatrixA2 <daughter 1> <daughter 2> <channel> <Re[a2(1320)]> <Im[a2(1320)]> ...
  * 
  *  Parameters:
  *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
@@ -24,16 +24,14 @@
  *     which, when added together, form the first decay product (e.g. 23 would sum particles
  *     2 and 3 to make a new state).
  *  2. <daughter 2>: Same as (1) but for the second decay product.
- *  3. <channel>: A single digit corresponding to the final state channel (see table).
- *     ╭────┬────┬─────╮
- *     │ 0  │ 1  │ 2   │
- *     ├────┼────┼─────┤
- *     │ πη │ KK̅ │ πη' │
- *     ╰────┴────┴─────╯
- *  4. a₂(1320) initial state coupling (real part)
- *  5. a₂(1320) initial state coupling (imaginary part)
- *  6. a₂(1700) initial state coupling (real part)
- *  7. a₂(1700) initial state coupling (imaginary part)
+ *  3. <channel>: A single digit corresponding to the final state channel:
+ *     0: pi-eta
+ *     1: K-Kbar
+ *     2: pi-eta'
+ *  4. a2(1320) initial state coupling (real part)
+ *  5. a2(1320) initial state coupling (imaginary part)
+ *  6. a2(1700) initial state coupling (real part)
+ *  7. a2(1700) initial state coupling (imaginary part)
  *
  *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
  */

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixA2.cc
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixA2.cc
@@ -1,0 +1,238 @@
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <complex>
+#include <cstdlib>
+#include <math.h>
+
+#include "TLorentzVector.h"
+
+#include "IUAmpTools/Kinematics.h"
+
+#include "AMPTOOLS_AMPS/barrierFactor.h"
+#include "AMPTOOLS_AMPS/breakupMomentum.h"
+#include "AMPTOOLS_AMPS/KopfKMatrixA2.h"
+
+/* 
+ *  Usage: KopfKMatrixA2 <daughter 1> <daughter 2> <channel> <Re[a₂(1320)]> <Im[a₂(1320)]> ...
+ * 
+ *  Parameters:
+ *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
+ *     the first decay product in the kinematic arrays. Note that this array typically starts
+ *     with the beam in location 0, so these values could be considered to be 1-indexed. If
+ *     the number is more than one digit long, each single digit will represent a particle
+ *     which, when added together, form the first decay product (e.g. 23 would sum particles
+ *     2 and 3 to make a new state).
+ *  2. <daughter 2>: Same as (1) but for the second decay product.
+ *  3. <channel>: A single digit corresponding to the final state channel (see table).
+ *     ╭────┬────┬─────╮
+ *     │ 0  │ 1  │ 2   │
+ *     ├────┼────┼─────┤
+ *     │ πη │ KK̅ │ πη' │
+ *     ╰────┴────┴─────╯
+ *  4. a₂(1320) initial state coupling (real part)
+ *  5. a₂(1320) initial state coupling (imaginary part)
+ *  6. a₂(1700) initial state coupling (real part)
+ *  7. a₂(1700) initial state coupling (imaginary part)
+ *
+ *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
+ */
+
+KopfKMatrixA2::KopfKMatrixA2(const vector<string> &args): UserAmplitude<KopfKMatrixA2>(args) {
+	assert(args.size() == 7);
+	m_daughters = pair<string, string>(args[0], args[1]);
+	channel = atoi(args[2].c_str());
+	ba21320_re = AmpParameter(args[3]);
+	ba21320_im = AmpParameter(args[4]);
+    ba21700_re = AmpParameter(args[5]);
+    ba21700_im = AmpParameter(args[6]);
+    registerParameter(ba21320_re);
+    registerParameter(ba21320_im);
+    registerParameter(ba21700_re);
+    registerParameter(ba21700_im);
+    ga21320 = SVector3(0.30073, 0.21426, -0.09162);
+    ga21700 = SVector3(0.68567, 0.12543, 0.00184);
+    masses = {1.30080, 1.75351};
+    couplings = {ga21320, ga21700};
+    m1s = {0.1349768, 0.493677, 0.1349768};
+    m2s = {0.547862, 0.497611, 0.95778};
+    a_bkg = {
+        -0.40184,
+        0.00033, -0.21416,
+        -0.08707, -0.06193, -0.17435};
+    mat_bkg = SMatrix3Sym(a_bkg.begin(), a_bkg.end());
+}
+
+void KopfKMatrixA2::calcUserVars(GDouble** pKin, GDouble* userVars) const {
+    TLorentzVector pTemp, pTot;
+    /* This allows us to input something like
+     * "12 34" for the daughter particle parameters
+     * to indicate that the first daughter is the
+     * sum of the final state particles indexed
+     * 1 and 2 and the second daughter is created
+     * from the sum of 3 and 4
+     */
+    for(unsigned int i=0; i < m_daughters.first.size(); ++i) {
+        string num; num += m_daughters.first[i];
+        int index = atoi(num.c_str());
+        pTemp.SetPxPyPzE(pKin[index][1],
+                         pKin[index][2],
+                         pKin[index][3],
+                         pKin[index][0]);
+        pTot += pTemp;
+    }
+    for(unsigned int i=0; i < m_daughters.second.size(); ++i) {
+        string num; num += m_daughters.second[i];
+        int index = atoi(num.c_str());
+        pTemp.SetPxPyPzE(pKin[index][1],
+                         pKin[index][2],
+                         pKin[index][3],
+                         pKin[index][0]);
+        pTot += pTemp;
+    }
+    // Grab our hypothesis mass
+    GDouble m = pTot.M();
+    userVars[kM] = m;
+    GDouble s = pTot.M2();
+    userVars[kS] = s;
+    // Calculate K-Matrix
+    SMatrix3 mat_K; // Initialized as a 3x3 0-matrix
+    SMatrix3 mat_C;
+    // Loop over resonances
+    for (int i = 0; i < 2; i++) {
+        SMatrix3 temp_K;
+        SMatrix3 temp_B;
+        temp_K = TensorProd(couplings[i], couplings[i]);
+        temp_K += (mat_bkg * (masses[i] * masses[i] - s));
+        temp_K *= KopfKMatrixA2::poleProductRemainder(s, i);
+        // Loop over channels: 
+        SVector3 B_factor;
+        for (int j = 0; j < 3; j++) {
+            GDouble q_alpha = fabs(breakupMomentum(masses[i], m1s[j], m2s[j]));
+            GDouble q = fabs(breakupMomentum(m, m1s[j], m2s[j]));
+            GDouble B_num = barrierFactor(q, 2);
+            GDouble B_den = barrierFactor(q_alpha, 2);
+            B_factor[j] = B_num / B_den;
+        }
+        temp_B = TensorProd(B_factor, B_factor); 
+        // Loop over channels: 
+        for (int k = 0; k < 3; k++) {
+            // Loop over channels: 
+            for (int l = 0; l < 3; l++) {
+                temp_K(k, l) = temp_K(k, l) * temp_B(k, l); // element-wise multiplication
+            }
+        }
+        mat_K += temp_K;
+    }
+    // Loop over channels
+    for (int j = 0; j < 3; j++) {
+        mat_C(j, j) = KopfKMatrixA2::chew(s, m1s[j], m2s[j]);
+    }
+    SMatrix3 temp;
+    complex<GDouble> product = KopfKMatrixA2::poleProduct(s);
+    for (int i = 0; i < 3; ++i) {
+        temp(i, i) = product;
+    }
+    mat_K *= mat_C;
+    temp += mat_K;
+    // Now temp is (I + KC)
+    SMatrix3 temp_inv = KopfKMatrixA2::inverse3(temp); // (I + KC)^{-1}
+    // Now we cache the results
+    for (int i = 0; i < 3; i++) {
+        userVars[i + 2] = temp_inv(channel, i).real(); // +2 because kM and kS are first in the enum
+        userVars[i + 2 + 3] = temp_inv(channel, i).imag(); // +3 to skip the real parts 
+    }
+}
+
+
+
+complex<GDouble> KopfKMatrixA2::calcAmplitude(GDouble** pKin, GDouble* userVars) const {
+    GDouble m = userVars[kM]; 
+    GDouble s = userVars[kS];
+    SVector3 vec_P;
+    vector<complex<GDouble>> betas{
+        complex<GDouble>(ba21320_re, ba21320_im),
+        complex<GDouble>(ba21700_re, ba21700_im),
+    };
+    // Loop over resonances
+    for (int i = 0; i < 2; i++) {
+        SVector3 temp_P;
+        SMatrix3 temp_B;
+        temp_P = couplings[i];
+        temp_P *= betas[i]; 
+        temp_P *= KopfKMatrixA2::poleProductRemainder(s, i);
+        SVector3 B_factor;
+        // Loop over channels:
+        for (int j = 0; j < 3; j++) {
+            GDouble q_alpha = fabs(breakupMomentum(masses[i], m1s[j], m2s[j]));
+            GDouble q = fabs(breakupMomentum(m, m1s[j], m2s[j]));
+            GDouble B_num = barrierFactor(q, 2);
+            GDouble B_den = barrierFactor(q_alpha, 2);
+            B_factor[j] = B_num / B_den;
+        }
+        temp_B = TensorProd(B_factor, B_factor); 
+        temp_P = temp_P * B_factor;
+        vec_P += temp_P;
+    }
+    SVector3 temp_inv;
+    // Loop over channels:
+    for (int i = 0; i < 3; i++) {
+        temp_inv(i) = complex<GDouble>(userVars[i + 2], userVars[i + 2 + 3]);
+    }
+    return Dot(temp_inv, vec_P);
+}
+
+SMatrix3 KopfKMatrixA2::inverse3(SMatrix3 A) const {
+    // A matrix inverse that works for complex values
+    SMatrix3 M;
+    SMatrix3 I = SMatrixIdentity();
+    SMatrix3 temp;
+    complex<GDouble> c = 1;
+    for (int k = 1; k <= 3; k++) {
+        M = A * M + I * c;
+        temp = A * M;
+        c = temp.Trace() / (-1.0 * k);
+    }
+    return M / (-1.0 * c);
+}
+
+complex<GDouble> KopfKMatrixA2::rho(double s, double m1, double m2) const {
+    return sqrt(complex<GDouble>(((1 - ((m1 + m2) * (m1 + m2) / s)) * (1 - ((m1 - m2) * (m1 - m2) / s))), 0));
+}
+
+complex<GDouble> KopfKMatrixA2::xi(double s, double m1, double m2) const {
+    return complex<GDouble>(1 - ((m1 + m2) * (m1 + m2) / s), 0);
+}
+
+complex<GDouble> KopfKMatrixA2::chew(double s, double m1, double m2) const {
+    // The Chew-Mandelstam matrix as described by Appendix B in <https://doi.org/10.1103/PhysRevD.91.054008>
+    complex<GDouble> tot = 0;
+    tot += (KopfKMatrixA2::rho(s, m1, m2) / Pi()) * log((KopfKMatrixA2::xi(s, m1, m2) + KopfKMatrixA2::rho(s, m1, m2)) / (KopfKMatrixA2::xi(s, m1, m2) - KopfKMatrixA2::rho(s, m1, m2)));
+    tot -= (KopfKMatrixA2::xi(s, m1, m2) / Pi()) * ((m2 - m1) / (m1 + m2)) * log(m2 / m1);
+    return tot;
+}
+
+complex<GDouble> KopfKMatrixA2::poleProduct(double s) const {
+    // We multiply the numerator and denominator by the product of poles to remove
+    // division by zero errors when the measured mass is computationally close to
+    // the pole mass.
+    complex<GDouble> tot = 1;
+    for (size_t i = 0; i < masses.size(); ++i) {
+        tot *= complex<GDouble>(masses[i] * masses[i] - s);
+    }
+    return tot;
+}
+
+complex<GDouble> KopfKMatrixA2::poleProductRemainder(double s, size_t index) const {
+    // We multiply the numerator and denominator by the product of poles to remove
+    // division by zero errors when the measured mass is computationally close to
+    // the pole mass.
+    complex<GDouble> tot = 1;
+    for (size_t i = 0; i < masses.size(); ++i) {
+        if (i == index) continue;
+        tot *= complex<GDouble>(masses[i] * masses[i] - s);
+    }
+    return tot;
+}
+
+void KopfKMatrixA2::updatePar(const AmpParameter &par) {}

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixA2.h
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixA2.h
@@ -22,7 +22,7 @@ typedef SMatrix<complex<GDouble>, 3, 3, ROOT::Math::MatRepSym<complex<GDouble>, 
 typedef SVector<complex<GDouble>, 3> SVector3;
 
 /* 
- *  Usage: KopfKMatrixA2 <daughter 1> <daughter 2> <channel> <Re[a₂(1320)]> <Im[a₂(1320)]> ...
+ *  Usage: KopfKMatrixA2 <daughter 1> <daughter 2> <channel> <Re[a2(1320)]> <Im[a2(1320)]> ...
  * 
  *  Parameters:
  *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
@@ -32,16 +32,14 @@ typedef SVector<complex<GDouble>, 3> SVector3;
  *     which, when added together, form the first decay product (e.g. 23 would sum particles
  *     2 and 3 to make a new state).
  *  2. <daughter 2>: Same as (1) but for the second decay product.
- *  3. <channel>: A single digit corresponding to the final state channel (see table).
- *     ╭────┬────┬─────╮
- *     │ 0  │ 1  │ 2   │
- *     ├────┼────┼─────┤
- *     │ πη │ KK̅ │ πη' │
- *     ╰────┴────┴─────╯
- *  4. a₂(1320) initial state coupling (real part)
- *  5. a₂(1320) initial state coupling (imaginary part)
- *  6. a₂(1700) initial state coupling (real part)
- *  7. a₂(1700) initial state coupling (imaginary part)
+ *  3. <channel>: A single digit corresponding to the final state channel:
+ *     0: pi-eta
+ *     1: K-Kbar
+ *     2: pi-eta'
+ *  4. a2(1320) initial state coupling (real part)
+ *  5. a2(1320) initial state coupling (imaginary part)
+ *  6. a2(1700) initial state coupling (real part)
+ *  7. a2(1700) initial state coupling (imaginary part)
  *
  *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
  */

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixA2.h
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixA2.h
@@ -1,0 +1,95 @@
+#if !defined(KOPFKMATRIXA2)
+#define KOPFKMATRIXA2
+
+#include "IUAmpTools/Amplitude.h"
+#include "IUAmpTools/AmpParameter.h"
+#include "IUAmpTools/UserAmplitude.h"
+#include "GPUManager/GPUCustomTypes.h"
+
+#include "Math/SVector.h"
+#include "Math/SMatrix.h"
+
+#include <utility>
+#include <string>
+#include <complex>
+#include <vector>
+
+using std::complex;
+using namespace std;
+using namespace ROOT::Math;
+typedef SMatrix<complex<GDouble>, 3> SMatrix3;
+typedef SMatrix<complex<GDouble>, 3, 3, ROOT::Math::MatRepSym<complex<GDouble>, 3>> SMatrix3Sym;
+typedef SVector<complex<GDouble>, 3> SVector3;
+
+/* 
+ *  Usage: KopfKMatrixA2 <daughter 1> <daughter 2> <channel> <Re[a₂(1320)]> <Im[a₂(1320)]> ...
+ * 
+ *  Parameters:
+ *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
+ *     the first decay product in the kinematic arrays. Note that this array typically starts
+ *     with the beam in location 0, so these values could be considered to be 1-indexed. If
+ *     the number is more than one digit long, each single digit will represent a particle
+ *     which, when added together, form the first decay product (e.g. 23 would sum particles
+ *     2 and 3 to make a new state).
+ *  2. <daughter 2>: Same as (1) but for the second decay product.
+ *  3. <channel>: A single digit corresponding to the final state channel (see table).
+ *     ╭────┬────┬─────╮
+ *     │ 0  │ 1  │ 2   │
+ *     ├────┼────┼─────┤
+ *     │ πη │ KK̅ │ πη' │
+ *     ╰────┴────┴─────╯
+ *  4. a₂(1320) initial state coupling (real part)
+ *  5. a₂(1320) initial state coupling (imaginary part)
+ *  6. a₂(1700) initial state coupling (real part)
+ *  7. a₂(1700) initial state coupling (imaginary part)
+ *
+ *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
+ */
+
+class Kinematics;
+
+class KopfKMatrixA2: public UserAmplitude<KopfKMatrixA2> {
+    public:
+        KopfKMatrixA2(): UserAmplitude<KopfKMatrixA2>() {}
+        KopfKMatrixA2(const vector<string> &args);
+	    enum UserVars {kM = 0, kS,
+            k0re, k1re, k2re,
+            k0im, k1im, k2im,
+            kNumUserVars};
+        unsigned int numUserVars() const {return kNumUserVars;}
+        void calcUserVars(GDouble** pKin, GDouble* userVars) const;
+        bool needsUserVarsOnly() const {return true;}
+        bool areUserVarsStatic() const {return true;}
+
+        ~KopfKMatrixA2(){}
+    
+        string name() const {return "KopfKMatrixA2";}
+
+        complex<GDouble> calcAmplitude(GDouble** pKin, GDouble* userVars) const;
+        void updatePar(const AmpParameter &par);
+
+    private:
+        pair<string, string> m_daughters;
+        int channel;
+        AmpParameter ba21320_re;
+        AmpParameter ba21320_im;
+        AmpParameter ba21700_re;
+        AmpParameter ba21700_im;
+
+        SVector3 ga21320;
+        SVector3 ga21700;
+        vector<SVector3> couplings;
+        vector<GDouble> masses;
+        vector<GDouble> m1s;
+        vector<GDouble> m2s;
+        vector<GDouble> a_bkg;
+        SMatrix3 mat_bkg;
+
+        SMatrix3 inverse3(SMatrix3 mat) const;
+        complex<GDouble> rho(double s, double m1, double m2) const;
+        complex<GDouble> xi(double s, double m1, double m2) const;
+        complex<GDouble> chew(double s, double m1, double m2) const;
+        complex<GDouble> poleProduct(double s) const;
+        complex<GDouble> poleProductRemainder(double s, size_t index) const;
+};
+#endif

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixF0.cc
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixF0.cc
@@ -14,7 +14,7 @@
 #include "AMPTOOLS_AMPS/KopfKMatrixF0.h"
 
 /* 
- *  Usage: KopfKMatrixF0 <daughter 1> <daughter 2> <channel> <Re[f₀(500)]> <Im[f₀(500)]> ...
+ *  Usage: KopfKMatrixF0 <daughter 1> <daughter 2> <channel> <Re[f0(500)]> <Im[f0(500)]> ...
  * 
  *  Parameters:
  *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
@@ -24,22 +24,22 @@
  *     which, when added together, form the first decay product (e.g. 23 would sum particles
  *     2 and 3 to make a new state).
  *  2. <daughter 2>: Same as (1) but for the second decay product.
- *  3. <channel>: A single digit corresponding to the final state channel (see table).
- *     ╭────┬──────┬────┬────┬─────╮
- *     │ 0  │ 1    │ 2  │ 3  │ 4   │
- *     ├────┼──────┼────┼────┼─────┤
- *     │ ππ │ 2π2π │ KK̅ │ ηη │ ηη' │
- *     ╰────┴──────┴────┴────┴─────╯
- *  4. f₀(500) initial state coupling (real part)
- *  5. f₀(500) initial state coupling (imaginary part)
- *  6. f₀(980) initial state coupling (real part)
- *  7. f₀(980) initial state coupling (imaginary part)
- *  8. f₀(1370) initial state coupling (real part)
- *  9. f₀(1370) initial state coupling (imaginary part)
- * 10. f₀(1500) initial state coupling (real part)
- * 11. f₀(1500) initial state coupling (imaginary part)
- * 12. f₀(1710) initial state coupling (real part)
- * 13. f₀(1710) initial state coupling (imaginary part)
+ *  3. <channel>: A single digit corresponding to the final state channel:
+ *     0: pi-pi
+ *     1: 2pi-2pi (effective channel for all decays into four pions not present in other channels)
+ *     2: K-Kbar
+ *     3: eta-eta
+ *     4: eta-eta'
+ *  4. f0(500) initial state coupling (real part)
+ *  5. f0(500) initial state coupling (imaginary part)
+ *  6. f0(980) initial state coupling (real part)
+ *  7. f0(980) initial state coupling (imaginary part)
+ *  8. f0(1370) initial state coupling (real part)
+ *  9. f0(1370) initial state coupling (imaginary part)
+ * 10. f0(1500) initial state coupling (real part)
+ * 11. f0(1500) initial state coupling (imaginary part)
+ * 12. f0(1710) initial state coupling (real part)
+ * 13. f0(1710) initial state coupling (imaginary part)
  *
  *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
  */

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixF0.cc
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixF0.cc
@@ -1,0 +1,265 @@
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <complex>
+#include <cstdlib>
+#include <math.h>
+
+#include "TLorentzVector.h"
+
+#include "IUAmpTools/Kinematics.h"
+
+#include "AMPTOOLS_AMPS/barrierFactor.h"
+#include "AMPTOOLS_AMPS/breakupMomentum.h"
+#include "AMPTOOLS_AMPS/KopfKMatrixF0.h"
+
+/* 
+ *  Usage: KopfKMatrixF0 <daughter 1> <daughter 2> <channel> <Re[f₀(500)]> <Im[f₀(500)]> ...
+ * 
+ *  Parameters:
+ *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
+ *     the first decay product in the kinematic arrays. Note that this array typically starts
+ *     with the beam in location 0, so these values could be considered to be 1-indexed. If
+ *     the number is more than one digit long, each single digit will represent a particle
+ *     which, when added together, form the first decay product (e.g. 23 would sum particles
+ *     2 and 3 to make a new state).
+ *  2. <daughter 2>: Same as (1) but for the second decay product.
+ *  3. <channel>: A single digit corresponding to the final state channel (see table).
+ *     ╭────┬──────┬────┬────┬─────╮
+ *     │ 0  │ 1    │ 2  │ 3  │ 4   │
+ *     ├────┼──────┼────┼────┼─────┤
+ *     │ ππ │ 2π2π │ KK̅ │ ηη │ ηη' │
+ *     ╰────┴──────┴────┴────┴─────╯
+ *  4. f₀(500) initial state coupling (real part)
+ *  5. f₀(500) initial state coupling (imaginary part)
+ *  6. f₀(980) initial state coupling (real part)
+ *  7. f₀(980) initial state coupling (imaginary part)
+ *  8. f₀(1370) initial state coupling (real part)
+ *  9. f₀(1370) initial state coupling (imaginary part)
+ * 10. f₀(1500) initial state coupling (real part)
+ * 11. f₀(1500) initial state coupling (imaginary part)
+ * 12. f₀(1710) initial state coupling (real part)
+ * 13. f₀(1710) initial state coupling (imaginary part)
+ *
+ *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
+ */
+
+KopfKMatrixF0::KopfKMatrixF0(const vector<string> &args): UserAmplitude<KopfKMatrixF0>(args) {
+	assert(args.size() == 13);
+	m_daughters = pair<string, string>(args[0], args[1]);
+	channel = atoi(args[2].c_str());
+	bf0500_re = AmpParameter(args[3]);
+	bf0500_im = AmpParameter(args[4]);
+    bf0980_re = AmpParameter(args[5]);
+    bf0980_im = AmpParameter(args[6]);
+    bf01370_re = AmpParameter(args[7]);
+    bf01370_im = AmpParameter(args[8]);
+    bf01500_re = AmpParameter(args[9]);
+    bf01500_im = AmpParameter(args[10]);
+    bf01710_re = AmpParameter(args[11]);
+    bf01710_im = AmpParameter(args[12]);
+    registerParameter(bf0500_re);
+    registerParameter(bf0500_im);
+    registerParameter(bf0980_re);
+    registerParameter(bf0980_im);
+    registerParameter(bf01370_re);
+    registerParameter(bf01370_im);
+    registerParameter(bf01500_re);
+    registerParameter(bf01500_im);
+    registerParameter(bf01710_re);
+    registerParameter(bf01710_im);
+    gf0500 = SVector5(0.74987, -0.01257, 0.27536, -0.15102, 0.36103);
+    gf0980 = SVector5(0.06401, 0.00204, 0.77413, 0.50999, 0.13112);
+    gf01370 = SVector5(-0.23417, -0.01032, 0.72283, 0.11934, 0.36792);
+    gf01500 = SVector5(0.01270, 0.26700, 0.09214, 0.02742, -0.04025);
+    gf01710 = SVector5(-0.14242, 0.22780, 0.15981, 0.16272, -0.17397);
+    masses = {0.51461, 0.90630, 1.23089, 1.46104, 1.69611};
+    couplings = {gf0500, gf0980, gf01370, gf01500, gf01710};
+    m1s = {0.1349768, 2*0.1349768, 0.493677, 0.547862, 0.547862};
+    m2s = {0.1349768, 2*0.1349768, 0.497611, 0.547862, 0.95778};
+    a_bkg = {
+        0.03728,
+        0.00000, 0.00000,
+        -0.01398, 0.00000, 0.02349,
+        -0.02203, 0.00000, 0.03101, -0.13769,
+        0.01397, 0.00000, -0.04003, -0.06722, -0.28401};
+    mat_bkg = SMatrix5Sym(a_bkg.begin(), a_bkg.end());
+}
+
+
+void KopfKMatrixF0::calcUserVars(GDouble** pKin, GDouble* userVars) const {
+    TLorentzVector pTemp, pTot;
+    /* This allows us to input something like
+     * "12 34" for the daughter particle parameters
+     * to indicate that the first daughter is the
+     * sum of the final state particles indexed
+     * 1 and 2 and the second daughter is created
+     * from the sum of 3 and 4
+     */
+    for(unsigned int i=0; i < m_daughters.first.size(); ++i) {
+        string num; num += m_daughters.first[i];
+        int index = atoi(num.c_str());
+        pTemp.SetPxPyPzE(pKin[index][1],
+                         pKin[index][2],
+                         pKin[index][3],
+                         pKin[index][0]);
+        pTot += pTemp;
+    }
+    for(unsigned int i=0; i < m_daughters.second.size(); ++i) {
+        string num; num += m_daughters.second[i];
+        int index = atoi(num.c_str());
+        pTemp.SetPxPyPzE(pKin[index][1],
+                         pKin[index][2],
+                         pKin[index][3],
+                         pKin[index][0]);
+        pTot += pTemp;
+    }
+    // Grab our hypothesis mass
+    GDouble m = pTot.M();
+    userVars[kM] = m;
+    GDouble s = pTot.M2();
+    userVars[kS] = s;
+    // Calculate K-Matrix
+    SMatrix5 mat_K; // Initialized as a 5x5 0-matrix
+    SMatrix5 mat_C;
+    // Loop over resonances
+    for (int i = 0; i < 5; i++) {
+        SMatrix5 temp_K;
+        SMatrix5 temp_B;
+        temp_K = TensorProd(couplings[i], couplings[i]);
+        temp_K += (mat_bkg * (masses[i] * masses[i] - s));
+        temp_K *= KopfKMatrixF0::poleProductRemainder(s, i); 
+        // Loop over channels:
+        SVector5 B_factor;
+        for (int j = 0; j < 5; j++) {
+            GDouble q_alpha = fabs(breakupMomentum(masses[i], m1s[j], m2s[j]));
+            GDouble q = fabs(breakupMomentum(m, m1s[j], m2s[j]));
+            GDouble B_num = barrierFactor(q, 0);
+            GDouble B_den = barrierFactor(q_alpha, 0);
+            B_factor[j] = B_num / B_den;
+        }
+        temp_B = TensorProd(B_factor, B_factor); 
+        // Loop over channels: 
+        for (int k = 0; k < 5; k++) {
+            // Loop over channels: 
+            for (int l = 0; l < 5; l++) {
+                temp_K(k, l) = temp_K(k, l) * temp_B(k, l); // element-wise multiplication
+            }
+        }
+        mat_K += temp_K;
+    }
+    // Loop over channels
+    for (int j = 0; j < 5; j++) {
+        mat_C(j, j) = KopfKMatrixF0::chew(s, m1s[j], m2s[j]);
+    }
+    SMatrix5 temp;
+    complex<GDouble> product = KopfKMatrixF0::poleProduct(s);
+    // Loop over channels
+    for (int i = 0; i < 5; ++i) {
+        temp(i, i) = product;
+    }
+    mat_K *= mat_C;
+    mat_K *= ((s - 0.0091125) / 1); // Adler zero term
+    temp += mat_K;
+    // Now temp is (I + KC)
+    SMatrix5 temp_inv = KopfKMatrixF0::inverse5(temp); // (I + KC)^{-1}
+    // Now we cache the results
+    for (int i = 0; i < 5; i++) {
+        userVars[i + 2] = temp_inv(channel, i).real(); // +2 because kM and kS are first in the enum
+        userVars[i + 2 + 5] = temp_inv(channel, i).imag(); // +5 to skip the real parts 
+    }
+}
+
+complex<GDouble> KopfKMatrixF0::calcAmplitude(GDouble** pKin, GDouble* userVars) const {
+    GDouble m = userVars[kM]; 
+    GDouble s = userVars[kS];
+    SVector5 vec_P;
+    vector<complex<GDouble>> betas{
+        complex<GDouble>(bf0500_re, bf0500_im),
+        complex<GDouble>(bf0980_re, bf0980_im),
+        complex<GDouble>(bf01370_re, bf01370_im),
+        complex<GDouble>(bf01500_re, bf01500_im),
+        complex<GDouble>(bf01710_re, bf01710_im)
+    };
+    // Loop over resonances
+    for (int i = 0; i < 5; i++) {
+        SVector5 temp_P;
+        SMatrix5 temp_B;
+        temp_P = couplings[i];
+        temp_P *= betas[i]; 
+        temp_P *= KopfKMatrixF0::poleProductRemainder(s, i);
+        SVector5 B_factor;
+        // Loop over channels:
+        for (int j = 0; j < 5; j++) {
+            GDouble q_alpha = fabs(breakupMomentum(masses[i], m1s[j], m2s[j]));
+            GDouble q = fabs(breakupMomentum(m, m1s[j], m2s[j]));
+            GDouble B_num = barrierFactor(q, 0);
+            GDouble B_den = barrierFactor(q_alpha, 0);
+            B_factor[j] = B_num / B_den;
+        }
+        temp_B = TensorProd(B_factor, B_factor); 
+        temp_P = temp_P * B_factor;
+        vec_P += temp_P;
+    }
+    SVector5 temp_inv;
+    // Loop over channels:
+    for (int i = 0; i < 5; i++) {
+        temp_inv(i) = complex<GDouble>(userVars[i + 2], userVars[i + 2 + 5]);
+    }
+    return Dot(temp_inv, vec_P);
+}
+
+SMatrix5 KopfKMatrixF0::inverse5(SMatrix5 A) const {
+    // A matrix inverse that works for complex values
+    SMatrix5 M;
+    SMatrix5 I = SMatrixIdentity();
+    SMatrix5 temp;
+    complex<GDouble> c = 1;
+    for (int k = 1; k <= 5; k++) {
+        M = A * M + I * c;
+        temp = A * M;
+        c = temp.Trace() / (-1.0 * k);
+    }
+    return M / (-1.0 * c);
+}
+
+complex<GDouble> KopfKMatrixF0::rho(double s, double m1, double m2) const {
+    return sqrt(complex<GDouble>(((1 - ((m1 + m2) * (m1 + m2) / s)) * (1 - ((m1 - m2) * (m1 - m2) / s))), 0));
+}
+
+complex<GDouble> KopfKMatrixF0::xi(double s, double m1, double m2) const {
+    return complex<GDouble>(1 - ((m1 + m2) * (m1 + m2) / s), 0);
+}
+
+complex<GDouble> KopfKMatrixF0::chew(double s, double m1, double m2) const {
+    // The Chew-Mandelstam matrix as described by Appendix B in <https://doi.org/10.1103/PhysRevD.91.054008>
+    complex<GDouble> tot = 0;
+    tot += (KopfKMatrixF0::rho(s, m1, m2) / Pi()) * log((KopfKMatrixF0::xi(s, m1, m2) + KopfKMatrixF0::rho(s, m1, m2)) / (KopfKMatrixF0::xi(s, m1, m2) - KopfKMatrixF0::rho(s, m1, m2)));
+    tot -= (KopfKMatrixF0::xi(s, m1, m2) / Pi()) * ((m2 - m1) / (m1 + m2)) * log(m2 / m1);
+    return tot;
+}
+
+complex<GDouble> KopfKMatrixF0::poleProduct(double s) const {
+    // We multiply the numerator and denominator by the product of poles to remove
+    // division by zero errors when the measured mass is computationally close to
+    // the pole mass.
+    complex<GDouble> tot = 1;
+    for (size_t i = 0; i < masses.size(); ++i) {
+        tot *= complex<GDouble>(masses[i] * masses[i] - s);
+    }
+    return tot;
+}
+
+complex<GDouble> KopfKMatrixF0::poleProductRemainder(double s, size_t index) const {
+    // We multiply the numerator and denominator by the product of poles to remove
+    // division by zero errors when the measured mass is computationally close to
+    // the pole mass.
+    complex<GDouble> tot = 1;
+    for (size_t i = 0; i < masses.size(); ++i) {
+        if (i == index) continue;
+        tot *= complex<GDouble>(masses[i] * masses[i] - s);
+    }
+    return tot;
+}
+
+void KopfKMatrixF0::updatePar(const AmpParameter &par) {}

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixF0.h
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixF0.h
@@ -22,7 +22,7 @@ typedef SMatrix<complex<GDouble>, 5, 5, ROOT::Math::MatRepSym<complex<GDouble>, 
 typedef SVector<complex<GDouble>, 5> SVector5;
 
 /* 
- *  Usage: KopfKMatrixF0 <daughter 1> <daughter 2> <channel> <Re[f₀(500)]> <Im[f₀(500)]> ...
+ *  Usage: KopfKMatrixF0 <daughter 1> <daughter 2> <channel> <Re[f0(500)]> <Im[f0(500)]> ...
  * 
  *  Parameters:
  *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
@@ -32,22 +32,22 @@ typedef SVector<complex<GDouble>, 5> SVector5;
  *     which, when added together, form the first decay product (e.g. 23 would sum particles
  *     2 and 3 to make a new state).
  *  2. <daughter 2>: Same as (1) but for the second decay product.
- *  3. <channel>: A single digit corresponding to the final state channel (see table).
- *     ╭────┬──────┬────┬────┬─────╮
- *     │ 0  │ 1    │ 2  │ 3  │ 4   │
- *     ├────┼──────┼────┼────┼─────┤
- *     │ ππ │ 2π2π │ KK̅ │ ηη │ ηη' │
- *     ╰────┴──────┴────┴────┴─────╯
- *  4. f₀(500) initial state coupling (real part)
- *  5. f₀(500) initial state coupling (imaginary part)
- *  6. f₀(980) initial state coupling (real part)
- *  7. f₀(980) initial state coupling (imaginary part)
- *  8. f₀(1370) initial state coupling (real part)
- *  9. f₀(1370) initial state coupling (imaginary part)
- * 10. f₀(1500) initial state coupling (real part)
- * 11. f₀(1500) initial state coupling (imaginary part)
- * 12. f₀(1710) initial state coupling (real part)
- * 13. f₀(1710) initial state coupling (imaginary part)
+ *  3. <channel>: A single digit corresponding to the final state channel:
+ *     0: pi-pi
+ *     1: 2pi-2pi (effective channel for all decays into four pions not present in other channels)
+ *     2: K-Kbar
+ *     3: eta-eta
+ *     4: eta-eta'
+ *  4. f0(500) initial state coupling (real part)
+ *  5. f0(500) initial state coupling (imaginary part)
+ *  6. f0(980) initial state coupling (real part)
+ *  7. f0(980) initial state coupling (imaginary part)
+ *  8. f0(1370) initial state coupling (real part)
+ *  9. f0(1370) initial state coupling (imaginary part)
+ * 10. f0(1500) initial state coupling (real part)
+ * 11. f0(1500) initial state coupling (imaginary part)
+ * 12. f0(1710) initial state coupling (real part)
+ * 13. f0(1710) initial state coupling (imaginary part)
  *
  *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
  */

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixF0.h
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixF0.h
@@ -1,0 +1,110 @@
+#if !defined(KOPFKMATRIXF0)
+#define KOPFKMATRIXF0
+
+#include "IUAmpTools/Amplitude.h"
+#include "IUAmpTools/AmpParameter.h"
+#include "IUAmpTools/UserAmplitude.h"
+#include "GPUManager/GPUCustomTypes.h"
+
+#include "Math/SVector.h"
+#include "Math/SMatrix.h"
+
+#include <utility>
+#include <string>
+#include <complex>
+#include <vector>
+
+using std::complex;
+using namespace std;
+using namespace ROOT::Math;
+typedef SMatrix<complex<GDouble>, 5> SMatrix5;
+typedef SMatrix<complex<GDouble>, 5, 5, ROOT::Math::MatRepSym<complex<GDouble>, 5>> SMatrix5Sym;
+typedef SVector<complex<GDouble>, 5> SVector5;
+
+/* 
+ *  Usage: KopfKMatrixF0 <daughter 1> <daughter 2> <channel> <Re[f₀(500)]> <Im[f₀(500)]> ...
+ * 
+ *  Parameters:
+ *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
+ *     the first decay product in the kinematic arrays. Note that this array typically starts
+ *     with the beam in location 0, so these values could be considered to be 1-indexed. If
+ *     the number is more than one digit long, each single digit will represent a particle
+ *     which, when added together, form the first decay product (e.g. 23 would sum particles
+ *     2 and 3 to make a new state).
+ *  2. <daughter 2>: Same as (1) but for the second decay product.
+ *  3. <channel>: A single digit corresponding to the final state channel (see table).
+ *     ╭────┬──────┬────┬────┬─────╮
+ *     │ 0  │ 1    │ 2  │ 3  │ 4   │
+ *     ├────┼──────┼────┼────┼─────┤
+ *     │ ππ │ 2π2π │ KK̅ │ ηη │ ηη' │
+ *     ╰────┴──────┴────┴────┴─────╯
+ *  4. f₀(500) initial state coupling (real part)
+ *  5. f₀(500) initial state coupling (imaginary part)
+ *  6. f₀(980) initial state coupling (real part)
+ *  7. f₀(980) initial state coupling (imaginary part)
+ *  8. f₀(1370) initial state coupling (real part)
+ *  9. f₀(1370) initial state coupling (imaginary part)
+ * 10. f₀(1500) initial state coupling (real part)
+ * 11. f₀(1500) initial state coupling (imaginary part)
+ * 12. f₀(1710) initial state coupling (real part)
+ * 13. f₀(1710) initial state coupling (imaginary part)
+ *
+ *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
+ */
+
+class Kinematics;
+
+class KopfKMatrixF0: public UserAmplitude<KopfKMatrixF0> {
+    public:
+        KopfKMatrixF0(): UserAmplitude<KopfKMatrixF0>() {}
+        KopfKMatrixF0(const vector<string> &args);
+	    enum UserVars {kM = 0, kS,
+            k0re, k1re, k2re, k3re, k4re,
+            k0im, k1im, k2im, k3im, k4im,
+            kNumUserVars};
+        unsigned int numUserVars() const {return kNumUserVars;}
+        void calcUserVars(GDouble** pKin, GDouble* userVars) const;
+        bool needsUserVarsOnly() const {return true;}
+        bool areUserVarsStatic() const {return true;}
+        
+        ~KopfKMatrixF0(){}
+    
+        string name() const {return "KopfKMatrixF0";}
+
+        complex<GDouble> calcAmplitude(GDouble** pKin, GDouble* userVars) const;
+        void updatePar(const AmpParameter &par);
+
+    private:
+        pair<string, string> m_daughters;
+        int channel;
+        AmpParameter bf0500_re;
+        AmpParameter bf0500_im;
+        AmpParameter bf0980_re;
+        AmpParameter bf0980_im;
+        AmpParameter bf01370_re;
+        AmpParameter bf01370_im;
+        AmpParameter bf01500_re;
+        AmpParameter bf01500_im;
+        AmpParameter bf01710_re;
+        AmpParameter bf01710_im;
+
+        SVector5 gf0500;
+        SVector5 gf0980;
+        SVector5 gf01370;
+        SVector5 gf01500;
+        SVector5 gf01710;
+        vector<SVector5> couplings;
+        vector<GDouble> masses;
+        vector<GDouble> m1s;
+        vector<GDouble> m2s;
+        vector<GDouble> a_bkg;
+        SMatrix5 mat_bkg;
+
+        SMatrix5 inverse5(SMatrix5 mat) const;
+        complex<GDouble> rho(double s, double m1, double m2) const;
+        complex<GDouble> xi(double s, double m1, double m2) const;
+        complex<GDouble> chew(double s, double m1, double m2) const;
+        complex<GDouble> poleProduct(double s) const;
+        complex<GDouble> poleProductRemainder(double s, size_t index) const;
+};
+#endif

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixF2.cc
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixF2.cc
@@ -178,7 +178,6 @@ complex<GDouble> KopfKMatrixF2::calcAmplitude(GDouble** pKin, GDouble* userVars)
         SMatrix4 temp_B;
         temp_P = couplings[i];
         temp_P *= betas[i]; 
-        GDouble denominator = (masses[i] * masses[i] - s);
         temp_P *= KopfKMatrixF2::poleProductRemainder(s, i);
         // Loop over channels:
         SVector4 B_factor;

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixF2.cc
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixF2.cc
@@ -1,0 +1,257 @@
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <complex>
+#include <cstdlib>
+#include <math.h>
+
+#include "TLorentzVector.h"
+
+#include "IUAmpTools/Kinematics.h"
+
+#include "AMPTOOLS_AMPS/breakupMomentum.h"
+#include "AMPTOOLS_AMPS/barrierFactor.h"
+#include "AMPTOOLS_AMPS/KopfKMatrixF2.h"
+
+/* 
+ *  Usage: KopfKMatrixF2 <daughter 1> <daughter 2> <channel> <Re[f₂(1270)]> <Im[f₂(1270)]> ...
+ * 
+ *  Parameters:
+ *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
+ *     the first decay product in the kinematic arrays. Note that this array typically starts
+ *     with the beam in location 0, so these values could be considered to be 1-indexed. If
+ *     the number is more than one digit long, each single digit will represent a particle
+ *     which, when added together, form the first decay product (e.g. 23 would sum particles
+ *     2 and 3 to make a new state).
+ *  2. <daughter 2>: Same as (1) but for the second decay product.
+ *  3. <channel>: A single digit corresponding to the final state channel (see table).
+ *     ╭────┬──────┬────┬────╮
+ *     │ 0  │ 1    │ 2  │ 3  │
+ *     ├────┼──────┼────┼────┤
+ *     │ ππ │ 2π2π │ KK̅ │ ηη │
+ *     ╰────┴──────┴────┴────╯
+ *  4. f₂(1270) initial state coupling (real part)
+ *  5. f₂(1270) initial state coupling (imaginary part)
+ *  6. f₂'(1525) initial state coupling (real part)
+ *  7. f₂'(1525) initial state coupling (imaginary part)
+ *  8. f₂(1810) initial state coupling (real part)
+ *  9. f₂(1810) initial state coupling (imaginary part)
+ * 10. f₂(1950) initial state coupling (real part)
+ * 11. f₂(1950) initial state coupling (imaginary part)
+ *
+ *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
+ */
+
+KopfKMatrixF2::KopfKMatrixF2(const vector<string> &args): UserAmplitude<KopfKMatrixF2>(args) {
+	assert(args.size() == 11);
+	m_daughters = pair<string, string>(args[0], args[1]);
+	channel = atoi(args[2].c_str());
+	bf21270_re = AmpParameter(args[3]);
+	bf21270_im = AmpParameter(args[4]);
+    bf21525_re = AmpParameter(args[5]);
+    bf21525_im = AmpParameter(args[6]);
+    bf21810_re = AmpParameter(args[7]);
+    bf21810_im = AmpParameter(args[8]);
+    bf21950_re = AmpParameter(args[9]);
+    bf21950_im = AmpParameter(args[10]);
+    registerParameter(bf21270_re);
+    registerParameter(bf21270_im);
+    registerParameter(bf21525_re);
+    registerParameter(bf21525_im);
+    registerParameter(bf21810_re);
+    registerParameter(bf21810_im);
+    registerParameter(bf21950_re);
+    registerParameter(bf21950_im);
+    gf21270 = SVector4(0.40033, 0.15479, -0.08900, -0.00113);
+    gf21525 = SVector4(0.01820, 0.17300, 0.32393, 0.15256);
+    gf21810 = SVector4(-0.06709, 0.22941, -0.43133, 0.23721);
+    gf21950 = SVector4(-0.49924, 0.19295, 0.27975, -0.03987);
+    masses = {1.15299, 1.48359, 1.72923, 1.96700};
+    couplings = {gf21270, gf21525, gf21810, gf21950};
+    m1s = {0.1349768, 2*0.1349768, 0.493677, 0.547862};
+    m2s = {0.1349768, 2*0.1349768, 0.497611, 0.547862};
+    a_bkg = {
+        -0.04319,
+        0.00000, 0.00000,
+        0.00984, 0.00000, -0.07344,
+        0.01028, 0.00000, 0.05533, -0.05183};
+    mat_bkg = SMatrix4Sym(a_bkg.begin(), a_bkg.end());
+}
+
+void KopfKMatrixF2::calcUserVars(GDouble** pKin, GDouble* userVars) const {
+    TLorentzVector pTemp, pTot;
+    /* This allows us to input something like
+     * "12 34" for the daughter particle parameters
+     * to indicate that the first daughter is the
+     * sum of the final state particles indexed
+     * 1 and 2 and the second daughter is created
+     * from the sum of 3 and 4
+     */
+    for(unsigned int i=0; i < m_daughters.first.size(); ++i) {
+        string num; num += m_daughters.first[i];
+        int index = atoi(num.c_str());
+        pTemp.SetPxPyPzE(pKin[index][1],
+                         pKin[index][2],
+                         pKin[index][3],
+                         pKin[index][0]);
+        pTot += pTemp;
+    }
+    for(unsigned int i=0; i < m_daughters.second.size(); ++i) {
+        string num; num += m_daughters.second[i];
+        int index = atoi(num.c_str());
+        pTemp.SetPxPyPzE(pKin[index][1],
+                         pKin[index][2],
+                         pKin[index][3],
+                         pKin[index][0]);
+        pTot += pTemp;
+    }
+    // Grab our hypothesis mass
+    GDouble m = pTot.M();
+    userVars[kM] = m;
+    GDouble s = pTot.M2();
+    userVars[kS] = s;
+    // Calculate K-Matrix
+    SMatrix4 mat_K; // Initialized as a 4x4 0-matrix
+    SMatrix4 mat_C;
+    // Loop over resonances
+    for (int i = 0; i < 4; i++) {
+        SMatrix4 temp_K;
+        SMatrix4 temp_B;
+        temp_K = TensorProd(couplings[i], couplings[i]);
+        temp_K += (mat_bkg * (masses[i] * masses[i] - s));
+        temp_K *= KopfKMatrixF2::poleProductRemainder(s, i);
+        // Loop over channels: 
+        SVector4 B_factor;
+        for (int j = 0; j < 4; j++) {
+            GDouble q_alpha = fabs(breakupMomentum(masses[i], m1s[j], m2s[j]));
+            GDouble q = fabs(breakupMomentum(m, m1s[j], m2s[j]));
+            GDouble B_num = barrierFactor(q, 2);
+            GDouble B_den = barrierFactor(q_alpha, 2);
+            B_factor[j] = B_num / B_den;
+        }
+        temp_B = TensorProd(B_factor, B_factor); 
+        // Loop over channels: 
+        for (int k = 0; k < 4; k++) {
+            // Loop over channels: 
+            for (int l = 0; l < 4; l++) {
+                temp_K(k, l) = temp_K(k, l) * temp_B(k, l); // element-wise multiplication
+            }
+        }
+        mat_K += temp_K;
+    }
+    // Loop over channels
+    for (int j = 0; j < 4; j++) {
+        mat_C(j, j) = KopfKMatrixF2::chew(s, m1s[j], m2s[j]);
+    }
+    SMatrix4 temp;
+    complex<GDouble> product = KopfKMatrixF2::poleProduct(s);
+    // Loop over channels
+    for (int i = 0; i < 4; ++i) {
+        temp(i, i) = product;
+    }
+    mat_K *= mat_C;
+    temp += mat_K;
+    // Now temp is (I + KC)
+    SMatrix4 temp_inv = KopfKMatrixF2::inverse4(temp); // (I + KC)^{-1}
+    // Now we cache the results
+    for (int i = 0; i < 4; i++) {
+        userVars[i + 2] = temp_inv(channel, i).real(); // +2 because kM and kS are first in the enum
+        userVars[i + 2 + 4] = temp_inv(channel, i).imag(); // +4 to skip the real parts 
+    }
+}
+
+
+
+complex<GDouble> KopfKMatrixF2::calcAmplitude(GDouble** pKin, GDouble* userVars) const {
+    GDouble m = userVars[kM]; 
+    GDouble s = userVars[kS];
+    SVector4 vec_P;
+    vector<complex<GDouble>> betas{
+        complex<GDouble>(bf21270_re, bf21270_im),
+        complex<GDouble>(bf21525_re, bf21525_im),
+        complex<GDouble>(bf21810_re, bf21810_im),
+        complex<GDouble>(bf21950_re, bf21950_im)
+    };
+    // Loop over resonances
+    for (int i = 0; i < 4; i++) {
+        SVector4 temp_P;
+        SMatrix4 temp_B;
+        temp_P = couplings[i];
+        temp_P *= betas[i]; 
+        GDouble denominator = (masses[i] * masses[i] - s);
+        temp_P *= KopfKMatrixF2::poleProductRemainder(s, i);
+        // Loop over channels:
+        SVector4 B_factor;
+        for (int j = 0; j < 4; j++) {
+            GDouble q_alpha = fabs(breakupMomentum(masses[i], m1s[j], m2s[j]));
+            GDouble q = fabs(breakupMomentum(m, m1s[j], m2s[j]));
+            GDouble B_num = barrierFactor(q, 2);
+            GDouble B_den = barrierFactor(q_alpha, 2);
+            B_factor[j] = B_num / B_den;
+        }
+        temp_B = TensorProd(B_factor, B_factor); 
+        temp_P = temp_P * B_factor;
+        vec_P += temp_P;
+    }
+    SVector4 temp_inv;
+    // Loop over channels:
+    for (int i = 0; i < 4; i++) {
+        temp_inv(i) = complex<GDouble>(userVars[i + 2], userVars[i + 2 + 4]);
+    }
+    return Dot(temp_inv, vec_P);
+}
+
+SMatrix4 KopfKMatrixF2::inverse4(SMatrix4 A) const {
+    // A matrix inverse that works for complex values
+    SMatrix4 M;
+    SMatrix4 I = SMatrixIdentity();
+    SMatrix4 temp;
+    complex<GDouble> c = 1;
+    for (int k = 1; k <= 4; k++) {
+        M = A * M + I * c;
+        temp = A * M;
+        c = temp.Trace() / (-1.0 * k);
+    }
+    return M / (-1.0 * c);
+}
+
+complex<GDouble> KopfKMatrixF2::rho(double s, double m1, double m2) const {
+    return sqrt(complex<GDouble>(((1 - ((m1 + m2) * (m1 + m2) / s)) * (1 - ((m1 - m2) * (m1 - m2) / s))), 0));
+}
+
+complex<GDouble> KopfKMatrixF2::xi(double s, double m1, double m2) const {
+    return complex<GDouble>(1 - ((m1 + m2) * (m1 + m2) / s), 0);
+}
+
+complex<GDouble> KopfKMatrixF2::chew(double s, double m1, double m2) const {
+    // The Chew-Mandelstam matrix as described by Appendix B in <https://doi.org/10.1103/PhysRevD.91.054008>
+    complex<GDouble> tot = 0;
+    tot += (KopfKMatrixF2::rho(s, m1, m2) / Pi()) * log((KopfKMatrixF2::xi(s, m1, m2) + KopfKMatrixF2::rho(s, m1, m2)) / (KopfKMatrixF2::xi(s, m1, m2) - KopfKMatrixF2::rho(s, m1, m2)));
+    tot -= (KopfKMatrixF2::xi(s, m1, m2) / Pi()) * ((m2 - m1) / (m1 + m2)) * log(m2 / m1);
+    return tot;
+}
+
+complex<GDouble> KopfKMatrixF2::poleProduct(double s) const {
+    // We multiply the numerator and denominator by the product of poles to remove
+    // division by zero errors when the measured mass is computationally close to
+    // the pole mass.
+    complex<GDouble> tot = 1;
+    for (size_t i = 0; i < masses.size(); ++i) {
+        tot *= complex<GDouble>(masses[i] * masses[i] - s);
+    }
+    return tot;
+}
+
+complex<GDouble> KopfKMatrixF2::poleProductRemainder(double s, size_t index) const {
+    // We multiply the numerator and denominator by the product of poles to remove
+    // division by zero errors when the measured mass is computationally close to
+    // the pole mass.
+    complex<GDouble> tot = 1;
+    for (size_t i = 0; i < masses.size(); ++i) {
+        if (i == index) continue;
+        tot *= complex<GDouble>(masses[i] * masses[i] - s);
+    }
+    return tot;
+}
+
+void KopfKMatrixF2::updatePar(const AmpParameter &par) {}

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixF2.cc
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixF2.cc
@@ -14,7 +14,7 @@
 #include "AMPTOOLS_AMPS/KopfKMatrixF2.h"
 
 /* 
- *  Usage: KopfKMatrixF2 <daughter 1> <daughter 2> <channel> <Re[f₂(1270)]> <Im[f₂(1270)]> ...
+ *  Usage: KopfKMatrixF2 <daughter 1> <daughter 2> <channel> <Re[f2(1270)]> <Im[f2(1270)]> ...
  * 
  *  Parameters:
  *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
@@ -24,20 +24,19 @@
  *     which, when added together, form the first decay product (e.g. 23 would sum particles
  *     2 and 3 to make a new state).
  *  2. <daughter 2>: Same as (1) but for the second decay product.
- *  3. <channel>: A single digit corresponding to the final state channel (see table).
- *     ╭────┬──────┬────┬────╮
- *     │ 0  │ 1    │ 2  │ 3  │
- *     ├────┼──────┼────┼────┤
- *     │ ππ │ 2π2π │ KK̅ │ ηη │
- *     ╰────┴──────┴────┴────╯
- *  4. f₂(1270) initial state coupling (real part)
- *  5. f₂(1270) initial state coupling (imaginary part)
- *  6. f₂'(1525) initial state coupling (real part)
- *  7. f₂'(1525) initial state coupling (imaginary part)
- *  8. f₂(1810) initial state coupling (real part)
- *  9. f₂(1810) initial state coupling (imaginary part)
- * 10. f₂(1950) initial state coupling (real part)
- * 11. f₂(1950) initial state coupling (imaginary part)
+ *  3. <channel>: A single digit corresponding to the final state channel:
+ *     0: pi-pi
+ *     1: 2pi-2pi (effective channel for all decays into four pions not present in other channels)
+ *     2: K-Kbar
+ *     3: eta-eta
+ *  4. f2(1270) initial state coupling (real part)
+ *  5. f2(1270) initial state coupling (imaginary part)
+ *  6. f2'(1525) initial state coupling (real part)
+ *  7. f2'(1525) initial state coupling (imaginary part)
+ *  8. f2(1810) initial state coupling (real part)
+ *  9. f2(1810) initial state coupling (imaginary part)
+ * 10. f2(1950) initial state coupling (real part)
+ * 11. f2(1950) initial state coupling (imaginary part)
  *
  *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
  */

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixF2.h
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixF2.h
@@ -1,0 +1,105 @@
+#if !defined(KOPFKMATRIXF2)
+#define KOPFKMATRIXF2
+
+#include "IUAmpTools/Amplitude.h"
+#include "IUAmpTools/AmpParameter.h"
+#include "IUAmpTools/UserAmplitude.h"
+#include "GPUManager/GPUCustomTypes.h"
+
+#include "Math/SVector.h"
+#include "Math/SMatrix.h"
+
+#include <utility>
+#include <string>
+#include <complex>
+#include <vector>
+
+using std::complex;
+using namespace std;
+using namespace ROOT::Math;
+typedef SMatrix<complex<GDouble>, 4> SMatrix4;
+typedef SMatrix<complex<GDouble>, 4, 4, ROOT::Math::MatRepSym<complex<GDouble>, 4>> SMatrix4Sym;
+typedef SVector<complex<GDouble>, 4> SVector4;
+
+/* 
+ *  Usage: KopfKMatrixF2 <daughter 1> <daughter 2> <channel> <Re[f₂(1270)]> <Im[f₂(1270)]> ...
+ * 
+ *  Parameters:
+ *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
+ *     the first decay product in the kinematic arrays. Note that this array typically starts
+ *     with the beam in location 0, so these values could be considered to be 1-indexed. If
+ *     the number is more than one digit long, each single digit will represent a particle
+ *     which, when added together, form the first decay product (e.g. 23 would sum particles
+ *     2 and 3 to make a new state).
+ *  2. <daughter 2>: Same as (1) but for the second decay product.
+ *  3. <channel>: A single digit corresponding to the final state channel (see table).
+ *     ╭────┬──────┬────┬────╮
+ *     │ 0  │ 1    │ 2  │ 3  │
+ *     ├────┼──────┼────┼────┤
+ *     │ ππ │ 2π2π │ KK̅ │ ηη │
+ *     ╰────┴──────┴────┴────╯
+ *  4. f₂(1270) initial state coupling (real part)
+ *  5. f₂(1270) initial state coupling (imaginary part)
+ *  6. f₂'(1525) initial state coupling (real part)
+ *  7. f₂'(1525) initial state coupling (imaginary part)
+ *  8. f₂(1810) initial state coupling (real part)
+ *  9. f₂(1810) initial state coupling (imaginary part)
+ * 10. f₂(1950) initial state coupling (real part)
+ * 11. f₂(1950) initial state coupling (imaginary part)
+ *
+ *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
+ */
+
+class Kinematics;
+
+class KopfKMatrixF2: public UserAmplitude<KopfKMatrixF2> {
+    public:
+        KopfKMatrixF2(): UserAmplitude<KopfKMatrixF2>() {}
+        KopfKMatrixF2(const vector<string> &args);
+	    enum UserVars {kM = 0, kS,
+            k0re, k1re, k2re, k3re,
+            k0im, k1im, k2im, k3im,
+            kNumUserVars};
+        unsigned int numUserVars() const {return kNumUserVars;}
+        void calcUserVars(GDouble** pKin, GDouble* userVars) const;
+        bool needsUserVarsOnly() const {return true;}
+        bool areUserVarsStatic() const {return true;}
+
+        ~KopfKMatrixF2(){}
+    
+        string name() const {return "KopfKMatrixF2";}
+
+        complex<GDouble> calcAmplitude(GDouble** pKin, GDouble* userVars) const;
+        void updatePar(const AmpParameter &par);
+
+    private:
+        pair<string, string> m_daughters;
+        int channel;
+        AmpParameter bf21270_re;
+        AmpParameter bf21270_im;
+        AmpParameter bf21525_re;
+        AmpParameter bf21525_im;
+        AmpParameter bf21810_re;
+        AmpParameter bf21810_im;
+        AmpParameter bf21950_re;
+        AmpParameter bf21950_im;
+
+        SVector4 gf21270;
+        SVector4 gf21525;
+        SVector4 gf21810;
+        SVector4 gf21950;
+        vector<SVector4> couplings;
+        vector<GDouble> masses;
+        vector<GDouble> m1s;
+        vector<GDouble> m2s;
+        vector<GDouble> a_bkg;
+        SMatrix4 mat_bkg;
+
+        SMatrix4 inverse4(SMatrix4 mat) const;
+        complex<GDouble> rho(double s, double m1, double m2) const;
+        complex<GDouble> xi(double s, double m1, double m2) const;
+        complex<GDouble> chew(double s, double m1, double m2) const;
+        complex<GDouble> poleProduct(double s) const;
+        complex<GDouble> poleProductRemainder(double s, size_t index) const;
+};
+#endif

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixF2.h
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixF2.h
@@ -22,7 +22,7 @@ typedef SMatrix<complex<GDouble>, 4, 4, ROOT::Math::MatRepSym<complex<GDouble>, 
 typedef SVector<complex<GDouble>, 4> SVector4;
 
 /* 
- *  Usage: KopfKMatrixF2 <daughter 1> <daughter 2> <channel> <Re[f₂(1270)]> <Im[f₂(1270)]> ...
+ *  Usage: KopfKMatrixF2 <daughter 1> <daughter 2> <channel> <Re[f2(1270)]> <Im[f2(1270)]> ...
  * 
  *  Parameters:
  *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
@@ -32,20 +32,19 @@ typedef SVector<complex<GDouble>, 4> SVector4;
  *     which, when added together, form the first decay product (e.g. 23 would sum particles
  *     2 and 3 to make a new state).
  *  2. <daughter 2>: Same as (1) but for the second decay product.
- *  3. <channel>: A single digit corresponding to the final state channel (see table).
- *     ╭────┬──────┬────┬────╮
- *     │ 0  │ 1    │ 2  │ 3  │
- *     ├────┼──────┼────┼────┤
- *     │ ππ │ 2π2π │ KK̅ │ ηη │
- *     ╰────┴──────┴────┴────╯
- *  4. f₂(1270) initial state coupling (real part)
- *  5. f₂(1270) initial state coupling (imaginary part)
- *  6. f₂'(1525) initial state coupling (real part)
- *  7. f₂'(1525) initial state coupling (imaginary part)
- *  8. f₂(1810) initial state coupling (real part)
- *  9. f₂(1810) initial state coupling (imaginary part)
- * 10. f₂(1950) initial state coupling (real part)
- * 11. f₂(1950) initial state coupling (imaginary part)
+ *  3. <channel>: A single digit corresponding to the final state channel:
+ *     0: pi-pi
+ *     1: 2pi-2pi (effective channel for all decays into four pions not present in other channels)
+ *     2: K-Kbar
+ *     3: eta-eta
+ *  4. f2(1270) initial state coupling (real part)
+ *  5. f2(1270) initial state coupling (imaginary part)
+ *  6. f2'(1525) initial state coupling (real part)
+ *  7. f2'(1525) initial state coupling (imaginary part)
+ *  8. f2(1810) initial state coupling (real part)
+ *  9. f2(1810) initial state coupling (imaginary part)
+ * 10. f2(1950) initial state coupling (real part)
+ * 11. f2(1950) initial state coupling (imaginary part)
  *
  *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
  */

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixPi1.cc
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixPi1.cc
@@ -1,0 +1,230 @@
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <complex>
+#include <cstdlib>
+#include <math.h>
+
+#include "TLorentzVector.h"
+
+#include "IUAmpTools/Kinematics.h"
+
+#include "AMPTOOLS_AMPS/barrierFactor.h"
+#include "AMPTOOLS_AMPS/breakupMomentum.h"
+#include "AMPTOOLS_AMPS/KopfKMatrixPi1.h"
+
+/* 
+ *  Usage: KopfKMatrixPi1 <daughter 1> <daughter 2> <channel> <Re[π₁(1600)]> <Im[π₁(1600)]> ...
+ * 
+ *  Parameters:
+ *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
+ *     the first decay product in the kinematic arrays. Note that this array typically starts
+ *     with the beam in location 0, so these values could be considered to be 1-indexed. If
+ *     the number is more than one digit long, each single digit will represent a particle
+ *     which, when added together, form the first decay product (e.g. 23 would sum particles
+ *     2 and 3 to make a new state).
+ *  2. <daughter 2>: Same as (1) but for the second decay product.
+ *  3. <channel>: A single digit corresponding to the final state channel (see table).
+ *     ╭────┬─────╮
+ *     │ 0  │ 1   │
+ *     ├────┼─────┤
+ *     │ πη │ πη' │
+ *     ╰────┴─────╯
+ *  4. π₁(1600) initial state coupling (real part)
+ *  5. π₁(1600) initial state coupling (imaginary part)
+ *
+ *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
+ */
+
+KopfKMatrixPi1::KopfKMatrixPi1(const vector<string> &args): UserAmplitude<KopfKMatrixPi1>(args) {
+	assert(args.size() == 5);
+    m_daughters = pair<string, string>(args[0], args[1]);
+    channel = atoi(args[2].c_str());
+    bpi11600_re = AmpParameter(args[3]);
+    bpi11600_im = AmpParameter(args[4]);
+    registerParameter(bpi11600_re);
+    registerParameter(bpi11600_im);
+    gpi11600 = SVector2(0.80564, 1.04695);
+    masses = {1.38552};
+    couplings = {gpi11600};
+    m1s = {0.1349768, 0.1349768};
+    m2s = {0.547862, 0.95778};
+    a_bkg = {
+        1.05000,
+        0.15163, -0.24611};
+    mat_bkg = SMatrix2Sym(a_bkg.begin(), a_bkg.end());
+}
+
+void KopfKMatrixPi1::calcUserVars(GDouble** pKin, GDouble* userVars) const {
+    TLorentzVector pTemp, pTot;
+    /* This allows us to input something like
+     * "12 34" for the daughter particle parameters
+     * to indicate that the first daughter is the
+     * sum of the final state particles indexed
+     * 1 and 2 and the second daughter is created
+     * from the sum of 3 and 4
+     */
+    for(unsigned int i=0; i < m_daughters.first.size(); ++i) {
+        string num; num += m_daughters.first[i];
+        int index = atoi(num.c_str());
+        pTemp.SetPxPyPzE(pKin[index][1],
+                         pKin[index][2],
+                         pKin[index][3],
+                         pKin[index][0]);
+        pTot += pTemp;
+    }
+    for(unsigned int i=0; i < m_daughters.second.size(); ++i) {
+        string num; num += m_daughters.second[i];
+        int index = atoi(num.c_str());
+        pTemp.SetPxPyPzE(pKin[index][1],
+                         pKin[index][2],
+                         pKin[index][3],
+                         pKin[index][0]);
+        pTot += pTemp;
+    }
+    // Grab our hypothesis mass
+    GDouble m = pTot.M();
+    userVars[kM] = m;
+    GDouble s = pTot.M2();
+    userVars[kS] = s;
+    // Calculate K-Matrix
+    SMatrix2 mat_K; // Initialized as a 4x4 0-matrix
+    SMatrix2 mat_C;
+    // Loop over resonances
+    for (int i = 0; i < 2; i++) {
+        SMatrix2 temp_K;
+        SMatrix2 temp_B;
+        temp_K = TensorProd(couplings[i], couplings[i]);
+        temp_K += (mat_bkg * (masses[i] * masses[i] - s));
+        temp_K *= KopfKMatrixPi1::poleProductRemainder(s, i);
+        // Loop over channels: 
+        SVector2 B_factor;
+        for (int j = 0; j < 2; j++) {
+            GDouble q_alpha = fabs(breakupMomentum(masses[i], m1s[j], m2s[j]));
+            GDouble q = fabs(breakupMomentum(m, m1s[j], m2s[j]));
+            GDouble B_num = barrierFactor(q, 0);
+            GDouble B_den = barrierFactor(q_alpha, 0);
+            B_factor[j] = B_num / B_den;
+        }
+        temp_B = TensorProd(B_factor, B_factor); 
+        // Loop over channels: 
+        for (int k = 0; k < 2; k++) {
+            // Loop over channels: 
+            for (int l = 0; l < 2; l++) {
+                temp_K(k, l) = temp_K(k, l) * temp_B(k, l); // element-wise multiplication
+            }
+        }
+        mat_K += temp_K;
+    }
+    // Loop over channels
+    for (int j = 0; j < 2; j++) {
+        mat_C(j, j) = KopfKMatrixPi1::chew(s, m1s[j], m2s[j]);
+    }
+    SMatrix2 temp;
+    complex<GDouble> product = KopfKMatrixPi1::poleProduct(s);
+    // Loop over channels
+    for (int i = 0; i < 2; ++i) {
+        temp(i, i) = product;
+    }
+    mat_K *= mat_C;
+    temp += mat_K;
+    // Now temp is (I + KC)
+    SMatrix2 temp_inv = KopfKMatrixPi1::inverse2(temp); // (I + KC)^{-1}
+    // Now we cache the results
+    for (int i = 0; i < 2; i++) {
+        userVars[i + 2] = temp_inv(channel, i).real(); // +2 because kM and kS are first in the enum
+        userVars[i + 2 + 2] = temp_inv(channel, i).imag(); // +2 to skip the real parts 
+    }
+}
+
+
+
+complex<GDouble> KopfKMatrixPi1::calcAmplitude(GDouble** pKin, GDouble* userVars) const {
+    GDouble m = userVars[kM]; 
+    GDouble s = userVars[kS];
+    SVector2 vec_P;
+    vector<complex<GDouble>> betas{
+        complex<GDouble>(bpi11600_re, bpi11600_im),
+    };
+    // Loop over resonances
+    for (int i = 0; i < 2; i++) {
+        SVector2 temp_P;
+        SMatrix2 temp_B;
+        temp_P = couplings[i];
+        temp_P *= betas[i]; 
+        temp_P *= KopfKMatrixPi1::poleProductRemainder(s, i);
+        // Loop over channels:
+        SVector2 B_factor;
+        for (int j = 0; j < 2; j++) {
+            GDouble q_alpha = fabs(breakupMomentum(masses[i], m1s[j], m2s[j]));
+            GDouble q = fabs(breakupMomentum(m, m1s[j], m2s[j]));
+            GDouble B_num = barrierFactor(q, 0);
+            GDouble B_den = barrierFactor(q_alpha, 0);
+            B_factor[j] = B_num / B_den;
+        }
+        temp_B = TensorProd(B_factor, B_factor); 
+        temp_P = temp_P * B_factor;
+        vec_P += temp_P;
+    }
+    SVector2 temp_inv;
+    // Loop over channels:
+    for (int i = 0; i < 2; i++) {
+        temp_inv(i) = complex<GDouble>(userVars[i + 2], userVars[i + 2 + 2]);
+    }
+    return Dot(temp_inv, vec_P);
+}
+
+SMatrix2 KopfKMatrixPi1::inverse2(SMatrix2 A) const {
+    // A matrix inverse that works for complex values
+    SMatrix2 M;
+    SMatrix2 I = SMatrixIdentity();
+    SMatrix2 temp;
+    complex<GDouble> c = 1;
+    for (int k = 1; k <= 2; k++) {
+        M = A * M + I * c;
+        temp = A * M;
+        c = temp.Trace() / (-1.0 * k);
+    }
+    return M / (-1.0 * c);
+}
+
+complex<GDouble> KopfKMatrixPi1::rho(double s, double m1, double m2) const {
+    return sqrt(complex<GDouble>(((1 - ((m1 + m2) * (m1 + m2) / s)) * (1 - ((m1 - m2) * (m1 - m2) / s))), 0));
+}
+
+complex<GDouble> KopfKMatrixPi1::xi(double s, double m1, double m2) const {
+    return complex<GDouble>(1 - ((m1 + m2) * (m1 + m2) / s), 0);
+}
+
+complex<GDouble> KopfKMatrixPi1::chew(double s, double m1, double m2) const {
+    // The Chew-Mandelstam matrix as described by Appendix B in <https://doi.org/10.1103/PhysRevD.91.054008>
+    complex<GDouble> tot = 0;
+    tot += (KopfKMatrixPi1::rho(s, m1, m2) / Pi()) * log((KopfKMatrixPi1::xi(s, m1, m2) + KopfKMatrixPi1::rho(s, m1, m2)) / (KopfKMatrixPi1::xi(s, m1, m2) - KopfKMatrixPi1::rho(s, m1, m2)));
+    tot -= (KopfKMatrixPi1::xi(s, m1, m2) / Pi()) * ((m2 - m1) / (m1 + m2)) * log(m2 / m1);
+    return tot;
+}
+
+complex<GDouble> KopfKMatrixPi1::poleProduct(double s) const {
+    // We multiply the numerator and denominator by the product of poles to remove
+    // division by zero errors when the measured mass is computationally close to
+    // the pole mass.
+    complex<GDouble> tot = 1;
+    for (size_t i = 0; i < masses.size(); ++i) {
+        tot *= complex<GDouble>(masses[i] * masses[i] - s);
+    }
+    return tot;
+}
+
+complex<GDouble> KopfKMatrixPi1::poleProductRemainder(double s, size_t index) const {
+    // We multiply the numerator and denominator by the product of poles to remove
+    // division by zero errors when the measured mass is computationally close to
+    // the pole mass.
+    complex<GDouble> tot = 1;
+    for (size_t i = 0; i < masses.size(); ++i) {
+        if (i == index) continue;
+        tot *= complex<GDouble>(masses[i] * masses[i] - s);
+    }
+    return tot;
+}
+
+void KopfKMatrixPi1::updatePar(const AmpParameter &par) {}

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixPi1.cc
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixPi1.cc
@@ -14,7 +14,7 @@
 #include "AMPTOOLS_AMPS/KopfKMatrixPi1.h"
 
 /* 
- *  Usage: KopfKMatrixPi1 <daughter 1> <daughter 2> <channel> <Re[π₁(1600)]> <Im[π₁(1600)]> ...
+ *  Usage: KopfKMatrixPi1 <daughter 1> <daughter 2> <channel> <Re[π1(1600)]> <Im[π1(1600)]> ...
  * 
  *  Parameters:
  *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
@@ -24,14 +24,11 @@
  *     which, when added together, form the first decay product (e.g. 23 would sum particles
  *     2 and 3 to make a new state).
  *  2. <daughter 2>: Same as (1) but for the second decay product.
- *  3. <channel>: A single digit corresponding to the final state channel (see table).
- *     ╭────┬─────╮
- *     │ 0  │ 1   │
- *     ├────┼─────┤
- *     │ πη │ πη' │
- *     ╰────┴─────╯
- *  4. π₁(1600) initial state coupling (real part)
- *  5. π₁(1600) initial state coupling (imaginary part)
+ *  3. <channel>: A single digit corresponding to the final state channel:
+ *     0: pi-eta
+ *     1: pi-eta'
+ *  4. π1(1600) initial state coupling (real part)
+ *  5. π1(1600) initial state coupling (imaginary part)
  *
  *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
  */

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixPi1.cc
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixPi1.cc
@@ -14,7 +14,7 @@
 #include "AMPTOOLS_AMPS/KopfKMatrixPi1.h"
 
 /* 
- *  Usage: KopfKMatrixPi1 <daughter 1> <daughter 2> <channel> <Re[π1(1600)]> <Im[π1(1600)]> ...
+ *  Usage: KopfKMatrixPi1 <daughter 1> <daughter 2> <channel> <Re[pi1(1600)]> <Im[pi1(1600)]> ...
  * 
  *  Parameters:
  *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
@@ -27,8 +27,8 @@
  *  3. <channel>: A single digit corresponding to the final state channel:
  *     0: pi-eta
  *     1: pi-eta'
- *  4. π1(1600) initial state coupling (real part)
- *  5. π1(1600) initial state coupling (imaginary part)
+ *  4. pi1(1600) initial state coupling (real part)
+ *  5. pi1(1600) initial state coupling (imaginary part)
  *
  *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
  */

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixPi1.h
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixPi1.h
@@ -22,7 +22,7 @@ typedef SMatrix<complex<GDouble>, 2, 2, ROOT::Math::MatRepSym<complex<GDouble>, 
 typedef SVector<complex<GDouble>, 2> SVector2;
 
 /* 
- *  Usage: KopfKMatrixPi1 <daughter 1> <daughter 2> <channel> <Re[π₁(1600)]> <Im[π₁(1600)]> ...
+ *  Usage: KopfKMatrixPi1 <daughter 1> <daughter 2> <channel> <Re[π1(1600)]> <Im[π1(1600)]> ...
  * 
  *  Parameters:
  *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
@@ -32,14 +32,11 @@ typedef SVector<complex<GDouble>, 2> SVector2;
  *     which, when added together, form the first decay product (e.g. 23 would sum particles
  *     2 and 3 to make a new state).
  *  2. <daughter 2>: Same as (1) but for the second decay product.
- *  3. <channel>: A single digit corresponding to the final state channel (see table).
- *     ╭────┬─────╮
- *     │ 0  │ 1   │
- *     ├────┼─────┤
- *     │ πη │ πη' │
- *     ╰────┴─────╯
- *  4. π₁(1600) initial state coupling (real part)
- *  5. π₁(1600) initial state coupling (imaginary part)
+ *  3. <channel>: A single digit corresponding to the final state channel:
+ *     0: pi-eta
+ *     1: pi-eta'
+ *  4. π1(1600) initial state coupling (real part)
+ *  5. π1(1600) initial state coupling (imaginary part)
  *
  *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
  */

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixPi1.h
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixPi1.h
@@ -22,7 +22,7 @@ typedef SMatrix<complex<GDouble>, 2, 2, ROOT::Math::MatRepSym<complex<GDouble>, 
 typedef SVector<complex<GDouble>, 2> SVector2;
 
 /* 
- *  Usage: KopfKMatrixPi1 <daughter 1> <daughter 2> <channel> <Re[π1(1600)]> <Im[π1(1600)]> ...
+ *  Usage: KopfKMatrixPi1 <daughter 1> <daughter 2> <channel> <Re[pi1(1600)]> <Im[pi1(1600)]> ...
  * 
  *  Parameters:
  *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
@@ -35,8 +35,8 @@ typedef SVector<complex<GDouble>, 2> SVector2;
  *  3. <channel>: A single digit corresponding to the final state channel:
  *     0: pi-eta
  *     1: pi-eta'
- *  4. π1(1600) initial state coupling (real part)
- *  5. π1(1600) initial state coupling (imaginary part)
+ *  4. pi1(1600) initial state coupling (real part)
+ *  5. pi1(1600) initial state coupling (imaginary part)
  *
  *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
  */

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixPi1.h
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixPi1.h
@@ -1,0 +1,90 @@
+#if !defined(KOPFKMATRIXPI1)
+#define KOPFKMATRIXPI1
+
+#include "IUAmpTools/Amplitude.h"
+#include "IUAmpTools/AmpParameter.h"
+#include "IUAmpTools/UserAmplitude.h"
+#include "GPUManager/GPUCustomTypes.h"
+
+#include "Math/SVector.h"
+#include "Math/SMatrix.h"
+
+#include <utility>
+#include <string>
+#include <complex>
+#include <vector>
+
+using std::complex;
+using namespace std;
+using namespace ROOT::Math;
+typedef SMatrix<complex<GDouble>, 2> SMatrix2;
+typedef SMatrix<complex<GDouble>, 2, 2, ROOT::Math::MatRepSym<complex<GDouble>, 2>> SMatrix2Sym;
+typedef SVector<complex<GDouble>, 2> SVector2;
+
+/* 
+ *  Usage: KopfKMatrixPi1 <daughter 1> <daughter 2> <channel> <Re[π₁(1600)]> <Im[π₁(1600)]> ...
+ * 
+ *  Parameters:
+ *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
+ *     the first decay product in the kinematic arrays. Note that this array typically starts
+ *     with the beam in location 0, so these values could be considered to be 1-indexed. If
+ *     the number is more than one digit long, each single digit will represent a particle
+ *     which, when added together, form the first decay product (e.g. 23 would sum particles
+ *     2 and 3 to make a new state).
+ *  2. <daughter 2>: Same as (1) but for the second decay product.
+ *  3. <channel>: A single digit corresponding to the final state channel (see table).
+ *     ╭────┬─────╮
+ *     │ 0  │ 1   │
+ *     ├────┼─────┤
+ *     │ πη │ πη' │
+ *     ╰────┴─────╯
+ *  4. π₁(1600) initial state coupling (real part)
+ *  5. π₁(1600) initial state coupling (imaginary part)
+ *
+ *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
+ */
+
+class Kinematics;
+
+class KopfKMatrixPi1: public UserAmplitude<KopfKMatrixPi1> {
+    public:
+        KopfKMatrixPi1(): UserAmplitude<KopfKMatrixPi1>() {}
+        KopfKMatrixPi1(const vector<string> &args);
+	    enum UserVars {kM = 0, kS,
+            k0re, k1re,
+            k0im, k1im,
+            kNumUserVars};
+        unsigned int numUserVars() const {return kNumUserVars;}
+        void calcUserVars(GDouble** pKin, GDouble* userVars) const;
+        bool needsUserVarsOnly() const {return true;}
+        bool areUserVarsStatic() const {return true;}
+
+        ~KopfKMatrixPi1(){}
+    
+        string name() const {return "KopfKMatrixPi1";}
+
+        complex<GDouble> calcAmplitude(GDouble** pKin, GDouble* userVars) const;
+        void updatePar(const AmpParameter &par);
+
+    private:
+        pair<string, string> m_daughters;
+        int channel;
+        AmpParameter bpi11600_re;
+        AmpParameter bpi11600_im;
+
+        SVector2 gpi11600;
+        vector<SVector2> couplings;
+        vector<GDouble> masses;
+        vector<GDouble> m1s;
+        vector<GDouble> m2s;
+        vector<GDouble> a_bkg;
+        SMatrix2 mat_bkg;
+
+        SMatrix2 inverse2(SMatrix2 mat) const;
+        complex<GDouble> rho(double s, double m1, double m2) const;
+        complex<GDouble> xi(double s, double m1, double m2) const;
+        complex<GDouble> chew(double s, double m1, double m2) const;
+        complex<GDouble> poleProduct(double s) const;
+        complex<GDouble> poleProductRemainder(double s, size_t index) const;
+};
+#endif

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixRho.cc
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixRho.cc
@@ -14,7 +14,7 @@
 #include "AMPTOOLS_AMPS/KopfKMatrixRho.h"
 
 /* 
- *  Usage: KopfKMatrixRho <daughter 1> <daughter 2> <channel> <Re[ρ(770)]> <Im[ρ(770)]> ...
+ *  Usage: KopfKMatrixRho <daughter 1> <daughter 2> <channel> <Re[rho(770)]> <Im[rho(770)]> ...
  * 
  *  Parameters:
  *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
@@ -24,16 +24,14 @@
  *     which, when added together, form the first decay product (e.g. 23 would sum particles
  *     2 and 3 to make a new state).
  *  2. <daughter 2>: Same as (1) but for the second decay product.
- *  3. <channel>: A single digit corresponding to the final state channel (see table).
- *     ╭────┬──────┬────╮
- *     │ 0  │ 1    │ 2  │
- *     ├────┼──────┼────┤
- *     │ ππ │ 2π2π │ KK̅ │
- *     ╰────┴──────┴────╯
- *  4. ρ(770) initial state coupling (real part)
- *  5. ρ(770) initial state coupling (imaginary part)
- *  6. ρ(1700) initial state coupling (real part)
- *  7. ρ(1700) initial state coupling (imaginary part)
+ *  3. <channel>: A single digit corresponding to the final state channel:
+ *     0: pi-pi
+ *     1: 2pi-2pi (effective channel for all decays into four pions not present in other channels)
+ *     2: K-Kbar
+ *  4. rho(770) initial state coupling (real part)
+ *  5. rho(770) initial state coupling (imaginary part)
+ *  6. rho(1700) initial state coupling (real part)
+ *  7. rho(1700) initial state coupling (imaginary part)
  *
  *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
  */

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixRho.cc
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixRho.cc
@@ -1,0 +1,239 @@
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <complex>
+#include <cstdlib>
+#include <math.h>
+
+#include "TLorentzVector.h"
+
+#include "IUAmpTools/Kinematics.h"
+
+#include "AMPTOOLS_AMPS/barrierFactor.h"
+#include "AMPTOOLS_AMPS/breakupMomentum.h"
+#include "AMPTOOLS_AMPS/KopfKMatrixRho.h"
+
+/* 
+ *  Usage: KopfKMatrixRho <daughter 1> <daughter 2> <channel> <Re[ρ(770)]> <Im[ρ(770)]> ...
+ * 
+ *  Parameters:
+ *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
+ *     the first decay product in the kinematic arrays. Note that this array typically starts
+ *     with the beam in location 0, so these values could be considered to be 1-indexed. If
+ *     the number is more than one digit long, each single digit will represent a particle
+ *     which, when added together, form the first decay product (e.g. 23 would sum particles
+ *     2 and 3 to make a new state).
+ *  2. <daughter 2>: Same as (1) but for the second decay product.
+ *  3. <channel>: A single digit corresponding to the final state channel (see table).
+ *     ╭────┬──────┬────╮
+ *     │ 0  │ 1    │ 2  │
+ *     ├────┼──────┼────┤
+ *     │ ππ │ 2π2π │ KK̅ │
+ *     ╰────┴──────┴────╯
+ *  4. ρ(770) initial state coupling (real part)
+ *  5. ρ(770) initial state coupling (imaginary part)
+ *  6. ρ(1700) initial state coupling (real part)
+ *  7. ρ(1700) initial state coupling (imaginary part)
+ *
+ *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
+ */
+
+KopfKMatrixRho::KopfKMatrixRho(const vector<string> &args): UserAmplitude<KopfKMatrixRho>(args) {
+	assert(args.size() == 7);
+	m_daughters = pair<string, string>(args[0], args[1]);
+	channel = atoi(args[2].c_str());
+	brho770_re = AmpParameter(args[3]);
+	brho770_im = AmpParameter(args[4]);
+    brho1700_re = AmpParameter(args[5]);
+    brho1700_im = AmpParameter(args[6]);
+    registerParameter(brho770_re);
+    registerParameter(brho770_im);
+    registerParameter(brho1700_re);
+    registerParameter(brho1700_im);
+    grho770 = SVector3(0.28023, 0.01806, 0.06501);
+    grho1700 = SVector3(0.16318, 0.53879, 0.00495);
+    masses = {0.71093, 1.58660};
+    couplings = {grho770, grho1700};
+    m1s = {0.1349768, 2*0.1349768, 0.493677};
+    m2s = {0.1349768, 2*0.1349768, 0.497611};
+    a_bkg = {
+        -0.06948,
+        0.00000, 0.00000,
+        0.07958, 0.00000, -0.60000};
+    mat_bkg = SMatrix3Sym(a_bkg.begin(), a_bkg.end());
+}
+
+void KopfKMatrixRho::calcUserVars(GDouble** pKin, GDouble* userVars) const {
+    TLorentzVector pTemp, pTot;
+    /* This allows us to input something like
+     * "12 34" for the daughter particle parameters
+     * to indicate that the first daughter is the
+     * sum of the final state particles indexed
+     * 1 and 2 and the second daughter is created
+     * from the sum of 3 and 4
+     */
+    for(unsigned int i=0; i < m_daughters.first.size(); ++i) {
+        string num; num += m_daughters.first[i];
+        int index = atoi(num.c_str());
+        pTemp.SetPxPyPzE(pKin[index][1],
+                         pKin[index][2],
+                         pKin[index][3],
+                         pKin[index][0]);
+        pTot += pTemp;
+    }
+    for(unsigned int i=0; i < m_daughters.second.size(); ++i) {
+        string num; num += m_daughters.second[i];
+        int index = atoi(num.c_str());
+        pTemp.SetPxPyPzE(pKin[index][1],
+                         pKin[index][2],
+                         pKin[index][3],
+                         pKin[index][0]);
+        pTot += pTemp;
+    }
+    // Grab our hypothesis mass
+    GDouble m = pTot.M();
+    userVars[kM] = m;
+    GDouble s = pTot.M2();
+    userVars[kS] = s;
+    // Calculate K-Matrix
+    SMatrix3 mat_K; // Initialized as a 3x3 0-matrix
+    SMatrix3 mat_C;
+    // Loop over resonances
+    for (int i = 0; i < 2; i++) {
+        SMatrix3 temp_K;
+        SMatrix3 temp_B;
+        temp_K = TensorProd(couplings[i], couplings[i]);
+        temp_K += (mat_bkg * (masses[i] * masses[i] - s));
+        temp_K *= KopfKMatrixRho::poleProductRemainder(s, i);
+        // Loop over channels: 
+        SVector3 B_factor;
+        for (int j = 0; j < 3; j++) {
+            GDouble q_alpha = fabs(breakupMomentum(masses[i], m1s[j], m2s[j]));
+            GDouble q = fabs(breakupMomentum(m, m1s[j], m2s[j]));
+            GDouble B_num = barrierFactor(q, 2);
+            GDouble B_den = barrierFactor(q_alpha, 2);
+            B_factor[j] = B_num / B_den;
+        }
+        temp_B = TensorProd(B_factor, B_factor); 
+        // Loop over channels: 
+        for (int k = 0; k < 3; k++) {
+            // Loop over channels: 
+            for (int l = 0; l < 3; l++) {
+                temp_K(k, l) = temp_K(k, l) * temp_B(k, l); // element-wise multiplication
+            }
+        }
+        mat_K += temp_K;
+    }
+    // Loop over channels
+    for (int j = 0; j < 3; j++) {
+        mat_C(j, j) = KopfKMatrixRho::chew(s, m1s[j], m2s[j]);
+    }
+    SMatrix3 temp;
+    complex<GDouble> product = KopfKMatrixRho::poleProduct(s);
+    // Loop over channels
+    for (int i = 0; i < 3; ++i) {
+        temp(i, i) = product;
+    }
+    mat_K *= mat_C;
+    temp += mat_K;
+    // Now temp is (I + KC)
+    SMatrix3 temp_inv = KopfKMatrixRho::inverse3(temp); // (I + KC)^{-1}
+    // Now we cache the results
+    for (int i = 0; i < 3; i++) {
+        userVars[i + 2] = temp_inv(channel, i).real(); // +2 because kM and kS are first in the enum
+        userVars[i + 2 + 3] = temp_inv(channel, i).imag(); // +3 to skip the real parts 
+    }
+}
+
+
+
+complex<GDouble> KopfKMatrixRho::calcAmplitude(GDouble** pKin, GDouble* userVars) const {
+    GDouble m = userVars[kM]; 
+    GDouble s = userVars[kS];
+    SVector3 vec_P;
+    vector<complex<GDouble>> betas{
+        complex<GDouble>(brho770_re, brho770_im),
+        complex<GDouble>(brho1700_re, brho1700_im),
+    };
+    // Loop over resonances
+    for (int i = 0; i < 2; i++) {
+        SVector3 temp_P;
+        SMatrix3 temp_B;
+        temp_P = couplings[i];
+        temp_P *= betas[i]; 
+        temp_P *= KopfKMatrixRho::poleProductRemainder(s, i);
+        SVector3 B_factor;
+        // Loop over channels:
+        for (int j = 0; j < 3; j++) {
+            GDouble q_alpha = fabs(breakupMomentum(masses[i], m1s[j], m2s[j]));
+            GDouble q = fabs(breakupMomentum(m, m1s[j], m2s[j]));
+            GDouble B_num = barrierFactor(q, 2);
+            GDouble B_den = barrierFactor(q_alpha, 2);
+            B_factor[j] = B_num / B_den;
+        }
+        temp_B = TensorProd(B_factor, B_factor); 
+        temp_P = temp_P * B_factor;
+        vec_P += temp_P;
+    }
+    SVector3 temp_inv;
+    // Loop over channels: 
+    for (int i = 0; i < 3; i++) {
+        temp_inv(i) = complex<GDouble>(userVars[i + 2], userVars[i + 2 + 3]);
+    }
+    return Dot(temp_inv, vec_P);
+}
+
+SMatrix3 KopfKMatrixRho::inverse3(SMatrix3 A) const {
+    // A matrix inverse that works for complex values
+    SMatrix3 M;
+    SMatrix3 I = SMatrixIdentity();
+    SMatrix3 temp;
+    complex<GDouble> c = 1;
+    for (int k = 1; k <= 3; k++) {
+        M = A * M + I * c;
+        temp = A * M;
+        c = temp.Trace() / (-1.0 * k);
+    }
+    return M / (-1.0 * c);
+}
+
+complex<GDouble> KopfKMatrixRho::rho(double s, double m1, double m2) const {
+    return sqrt(complex<GDouble>(((1 - ((m1 + m2) * (m1 + m2) / s)) * (1 - ((m1 - m2) * (m1 - m2) / s))), 0));
+}
+
+complex<GDouble> KopfKMatrixRho::xi(double s, double m1, double m2) const {
+    return complex<GDouble>(1 - ((m1 + m2) * (m1 + m2) / s), 0);
+}
+
+complex<GDouble> KopfKMatrixRho::chew(double s, double m1, double m2) const {
+    // The Chew-Mandelstam matrix as described by Appendix B in <https://doi.org/10.1103/PhysRevD.91.054008>
+    complex<GDouble> tot = 0;
+    tot += (KopfKMatrixRho::rho(s, m1, m2) / Pi()) * log((KopfKMatrixRho::xi(s, m1, m2) + KopfKMatrixRho::rho(s, m1, m2)) / (KopfKMatrixRho::xi(s, m1, m2) - KopfKMatrixRho::rho(s, m1, m2)));
+    tot -= (KopfKMatrixRho::xi(s, m1, m2) / Pi()) * ((m2 - m1) / (m1 + m2)) * log(m2 / m1);
+    return tot;
+}
+
+complex<GDouble> KopfKMatrixRho::poleProduct(double s) const {
+    // We multiply the numerator and denominator by the product of poles to remove
+    // division by zero errors when the measured mass is computationally close to
+    // the pole mass.
+    complex<GDouble> tot = 1;
+    for (size_t i = 0; i < masses.size(); ++i) {
+        tot *= complex<GDouble>(masses[i] * masses[i] - s);
+    }
+    return tot;
+}
+
+complex<GDouble> KopfKMatrixRho::poleProductRemainder(double s, size_t index) const {
+    // We multiply the numerator and denominator by the product of poles to remove
+    // division by zero errors when the measured mass is computationally close to
+    // the pole mass.
+    complex<GDouble> tot = 1;
+    for (size_t i = 0; i < masses.size(); ++i) {
+        if (i == index) continue;
+        tot *= complex<GDouble>(masses[i] * masses[i] - s);
+    }
+    return tot;
+}
+
+void KopfKMatrixRho::updatePar(const AmpParameter &par) {}

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixRho.h
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixRho.h
@@ -1,0 +1,95 @@
+#if !defined(KOPFKMATRIXRHO)
+#define KOPFKMATRIXRHO
+
+#include "IUAmpTools/Amplitude.h"
+#include "IUAmpTools/AmpParameter.h"
+#include "IUAmpTools/UserAmplitude.h"
+#include "GPUManager/GPUCustomTypes.h"
+
+#include "Math/SVector.h"
+#include "Math/SMatrix.h"
+
+#include <utility>
+#include <string>
+#include <complex>
+#include <vector>
+
+using std::complex;
+using namespace std;
+using namespace ROOT::Math;
+typedef SMatrix<complex<GDouble>, 3> SMatrix3;
+typedef SMatrix<complex<GDouble>, 3, 3, ROOT::Math::MatRepSym<complex<GDouble>, 3>> SMatrix3Sym;
+typedef SVector<complex<GDouble>, 3> SVector3;
+
+/* 
+ *  Usage: KopfKMatrixRho <daughter 1> <daughter 2> <channel> <Re[ρ(770)]> <Im[ρ(770)]> ...
+ * 
+ *  Parameters:
+ *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
+ *     the first decay product in the kinematic arrays. Note that this array typically starts
+ *     with the beam in location 0, so these values could be considered to be 1-indexed. If
+ *     the number is more than one digit long, each single digit will represent a particle
+ *     which, when added together, form the first decay product (e.g. 23 would sum particles
+ *     2 and 3 to make a new state).
+ *  2. <daughter 2>: Same as (1) but for the second decay product.
+ *  3. <channel>: A single digit corresponding to the final state channel (see table).
+ *     ╭────┬──────┬────╮
+ *     │ 0  │ 1    │ 2  │
+ *     ├────┼──────┼────┤
+ *     │ ππ │ 2π2π │ KK̅ │
+ *     ╰────┴──────┴────╯
+ *  4. ρ(770) initial state coupling (real part)
+ *  5. ρ(770) initial state coupling (imaginary part)
+ *  6. ρ(1700) initial state coupling (real part)
+ *  7. ρ(1700) initial state coupling (imaginary part)
+ *
+ *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
+ */
+
+class Kinematics;
+
+class KopfKMatrixRho: public UserAmplitude<KopfKMatrixRho> {
+    public:
+        KopfKMatrixRho(): UserAmplitude<KopfKMatrixRho>() {}
+        KopfKMatrixRho(const vector<string> &args);
+	    enum UserVars {kM = 0, kS,
+            k0re, k1re, k2re,
+            k0im, k1im, k2im,
+            kNumUserVars};
+        unsigned int numUserVars() const {return kNumUserVars;}
+        void calcUserVars(GDouble** pKin, GDouble* userVars) const;
+        bool needsUserVarsOnly() const {return true;}
+        bool areUserVarsStatic() const {return true;}
+
+        ~KopfKMatrixRho(){}
+    
+        string name() const {return "KopfKMatrixRho";}
+
+        complex<GDouble> calcAmplitude(GDouble** pKin, GDouble* userVars) const;
+        void updatePar(const AmpParameter &par);
+
+    private:
+        pair<string, string> m_daughters;
+        int channel;
+        AmpParameter brho770_re;
+        AmpParameter brho770_im;
+        AmpParameter brho1700_re;
+        AmpParameter brho1700_im;
+
+        SVector3 grho770;
+        SVector3 grho1700;
+        vector<SVector3> couplings;
+        vector<GDouble> masses;
+        vector<GDouble> m1s;
+        vector<GDouble> m2s;
+        vector<GDouble> a_bkg;
+        SMatrix3 mat_bkg;
+
+        SMatrix3 inverse3(SMatrix3 mat) const;
+        complex<GDouble> rho(double s, double m1, double m2) const;
+        complex<GDouble> xi(double s, double m1, double m2) const;
+        complex<GDouble> chew(double s, double m1, double m2) const;
+        complex<GDouble> poleProduct(double s) const;
+        complex<GDouble> poleProductRemainder(double s, size_t index) const;
+};
+#endif

--- a/src/libraries/AMPTOOLS_AMPS/KopfKMatrixRho.h
+++ b/src/libraries/AMPTOOLS_AMPS/KopfKMatrixRho.h
@@ -22,7 +22,7 @@ typedef SMatrix<complex<GDouble>, 3, 3, ROOT::Math::MatRepSym<complex<GDouble>, 
 typedef SVector<complex<GDouble>, 3> SVector3;
 
 /* 
- *  Usage: KopfKMatrixRho <daughter 1> <daughter 2> <channel> <Re[ρ(770)]> <Im[ρ(770)]> ...
+ *  Usage: KopfKMatrixRho <daughter 1> <daughter 2> <channel> <Re[rho(770)]> <Im[rho(770)]> ...
  * 
  *  Parameters:
  *  1. <daughter 1>: a single digit number or pair of digits corresponding to the location of
@@ -32,16 +32,14 @@ typedef SVector<complex<GDouble>, 3> SVector3;
  *     which, when added together, form the first decay product (e.g. 23 would sum particles
  *     2 and 3 to make a new state).
  *  2. <daughter 2>: Same as (1) but for the second decay product.
- *  3. <channel>: A single digit corresponding to the final state channel (see table).
- *     ╭────┬──────┬────╮
- *     │ 0  │ 1    │ 2  │
- *     ├────┼──────┼────┤
- *     │ ππ │ 2π2π │ KK̅ │
- *     ╰────┴──────┴────╯
- *  4. ρ(770) initial state coupling (real part)
- *  5. ρ(770) initial state coupling (imaginary part)
- *  6. ρ(1700) initial state coupling (real part)
- *  7. ρ(1700) initial state coupling (imaginary part)
+ *  3. <channel>: A single digit corresponding to the final state channel:
+ *     0: pi-pi
+ *     1: 2pi-2pi (effective channel for all decays into four pions not present in other channels)
+ *     2: K-Kbar
+ *  4. rho(770) initial state coupling (real part)
+ *  5. rho(770) initial state coupling (imaginary part)
+ *  6. rho(1700) initial state coupling (real part)
+ *  7. rho(1700) initial state coupling (imaginary part)
  *
  *  See <https://doi.org/10.1140/epjc/s10052-021-09821-2> for more details.
  */

--- a/src/programs/AmplitudeAnalysis/fit/fit.cc
+++ b/src/programs/AmplitudeAnalysis/fit/fit.cc
@@ -48,6 +48,12 @@
 #include "AMPTOOLS_AMPS/Piecewise.h"
 #include "AMPTOOLS_AMPS/LowerVertexDelta.h"
 #include "AMPTOOLS_AMPS/SinglePS.h"
+#include "AMPTOOLS_AMPS/KopfKMatrixF0.h"
+#include "AMPTOOLS_AMPS/KopfKMatrixF2.h"
+#include "AMPTOOLS_AMPS/KopfKMatrixA0.h"
+#include "AMPTOOLS_AMPS/KopfKMatrixA2.h"
+#include "AMPTOOLS_AMPS/KopfKMatrixRho.h"
+#include "AMPTOOLS_AMPS/KopfKMatrixPi1.h"
 
 #include "MinuitInterface/MinuitMinimizationManager.h"
 #include "IUAmpTools/AmpToolsInterface.h"
@@ -365,6 +371,12 @@ int main( int argc, char* argv[] ){
    AmpToolsInterface::registerAmplitude( Piecewise() );
    AmpToolsInterface::registerAmplitude( LowerVertexDelta() );
    AmpToolsInterface::registerAmplitude( SinglePS() );
+   AmpToolsInterface::registerAmplitude( KopfKMatrixF0() );
+   AmpToolsInterface::registerAmplitude( KopfKMatrixF2() );
+   AmpToolsInterface::registerAmplitude( KopfKMatrixA0() );
+   AmpToolsInterface::registerAmplitude( KopfKMatrixA2() );
+   AmpToolsInterface::registerAmplitude( KopfKMatrixRho() );
+   AmpToolsInterface::registerAmplitude( KopfKMatrixPi1() );
 
    AmpToolsInterface::registerDataReader( ROOTDataReader() );
    AmpToolsInterface::registerDataReader( ROOTDataReaderBootstrap() );

--- a/src/programs/AmplitudeAnalysis/fitMPI/fitMPI.cc
+++ b/src/programs/AmplitudeAnalysis/fitMPI/fitMPI.cc
@@ -46,6 +46,12 @@
 #include "AMPTOOLS_AMPS/OmegaDalitz.h"
 #include "AMPTOOLS_AMPS/LowerVertexDelta.h"
 #include "AMPTOOLS_AMPS/SinglePS.h"
+#include "AMPTOOLS_AMPS/KopfKMatrixF0.h"
+#include "AMPTOOLS_AMPS/KopfKMatrixF2.h"
+#include "AMPTOOLS_AMPS/KopfKMatrixA0.h"
+#include "AMPTOOLS_AMPS/KopfKMatrixA2.h"
+#include "AMPTOOLS_AMPS/KopfKMatrixRho.h"
+#include "AMPTOOLS_AMPS/KopfKMatrixPi1.h"
 
 #include "MinuitInterface/MinuitMinimizationManager.h"
 #include "IUAmpToolsMPI/AmpToolsInterfaceMPI.h"
@@ -394,6 +400,12 @@ int main( int argc, char* argv[] ){
    AmpToolsInterface::registerAmplitude( OmegaDalitz() );
    AmpToolsInterface::registerAmplitude( LowerVertexDelta() );
    AmpToolsInterface::registerAmplitude( SinglePS() );
+   AmpToolsInterface::registerAmplitude( KopfKMatrixF0() );
+   AmpToolsInterface::registerAmplitude( KopfKMatrixF2() );
+   AmpToolsInterface::registerAmplitude( KopfKMatrixA0() );
+   AmpToolsInterface::registerAmplitude( KopfKMatrixA2() );
+   AmpToolsInterface::registerAmplitude( KopfKMatrixRho() );
+   AmpToolsInterface::registerAmplitude( KopfKMatrixPi1() );
 
    AmpToolsInterface::registerDataReader( DataReaderMPI<ROOTDataReader>() );
    AmpToolsInterface::registerDataReader( DataReaderMPI<ROOTDataReaderBootstrap>() );


### PR DESCRIPTION
This PR adds the following amplitudes, which follow the conventions and use the values found by Kopf et al.[^1]:
```
KopfKMatrixF0
KopfKMatrixF2
KopfKMatrixA0
KopfKMatrixA2
KopfKMatrixRho
KopfKMatrixPi1
```
These amplitudes are written with the K-matrix fixed to the values found in the paper, so the K-matrix itself is computed before the fit and the desired channel is stored as user data. The only free parameters at time of fit are the complex couplings to the initial state (photocouplings for GlueX). These amplitudes can also be thought of as a unitary way to combine Breit-Wigner-esque line shapes with branching to other channels in mind, and would ideally be used in a coupled-channel analysis. See the individual files for usage information and to see what channels they can be applied to.

[^1]: Kopf, B., Albrecht, M., Koch, H. et al. Investigation of the lightest hybrid meson candidate with a coupled-channel analysis of pp̄-, π⁻p-, and ππ-Data. Eur. Phys. J. C 81, 1056 (2021). https://doi.org/10.1140/epjc/s10052-021-09821-2