### PR TITLE
Avoid duplicate seedfile extension in PWA fit

### DIFF
--- a/src/programs/AmplitudeAnalysis/fit/fit.cc
+++ b/src/programs/AmplitudeAnalysis/fit/fit.cc
@@ -151,7 +151,10 @@ void runRndFits(ConfigurationInfo* cfgInfo, bool useMinos, bool hesse, int maxIt
     ati.finalizeFit(to_string(i));
 
     if( seedfile.size() != 0 && !fitFailed ){
-      string seedfile_rand = seedfile + Form("_%d.txt", i);
+      string seedfileBaseName = seedfile.substr(0, seedfile.find_last_of("."));
+      string seedfileExtension = seedfile.substr(seedfile.find_last_of("."));
+
+      string seedfile_rand = seedfileBaseName + Form("_%d%s", i, seedfileExtension.data());
       ati.fitResults()->writeSeed( seedfile_rand );
     }
 
@@ -168,7 +171,9 @@ void runRndFits(ConfigurationInfo* cfgInfo, bool useMinos, bool hesse, int maxIt
     cout << "MINIMUM LIKELIHOOD FROM " << minFitTag << " of " << numRnd << " RANDOM PRODUCTION PARS = " << minLL << endl;
     gSystem->Exec(Form("cp %s_%d.fit %s.fit", fitName.data(), minFitTag, fitName.data()));
     if( seedfile.size() != 0 )
-      gSystem->Exec(Form("cp %s_%d.txt %s.txt", seedfile.data(), minFitTag, seedfile.data()));
+      string seedfileBaseName = seedfile.substr(0, seedfile.find_last_of("."));
+      string seedfileExtension = seedfile.substr(seedfile.find_last_of("."));
+      gSystem->Exec(Form("cp %s_%d%s %s", seedfileBaseName.data(), minFitTag, seedfileExtension.data(), seedfile.data()));
   }
 }
 
@@ -249,7 +254,10 @@ void runParScan(ConfigurationInfo* cfgInfo, bool useMinos, bool hesse, int maxIt
     ati.finalizeFit(to_string(i));
 
     if( seedfile.size() != 0 && !fitFailed ){
-      string seedfile_scan = seedfile + Form("_scan_%d.txt", i);
+      string seedfileBaseName = seedfile.substr(0, seedfile.find_last_of("."));
+      string seedfileExtension = seedfile.substr(seedfile.find_last_of("."));
+
+      string seedfile_scan = seedfileBaseName + Form("_scan_%d%s", i, seedfileExtension.data());
       ati.fitResults()->writeSeed( seedfile_scan );
     }
   }
@@ -386,6 +394,16 @@ int main( int argc, char* argv[] ){
    AmpToolsInterface::registerDataReader( ROOTDataReaderTEM() );
    AmpToolsInterface::registerDataReader( ROOTDataReaderHist() );
    AmpToolsInterface::registerDataReader( FSRootDataReader() );
+
+   // normalize seedFile file extension if not already set by user
+   if (seedfile.size() != 0){
+     if (seedfile.find(".") == string::npos) seedfile += ".txt";
+     else{
+       // this ensures the file has an extension for cases like "./my_seed_file" 
+       string fileExtension = seedfile.substr(seedfile.find_last_of("."));
+       if (fileExtension.find("/") != string::npos) seedfile += ".txt";
+     }
+   }
 
    if(noFit)
      getLikelihood(cfgInfo);

--- a/src/programs/AmplitudeAnalysis/fit/fit.cc
+++ b/src/programs/AmplitudeAnalysis/fit/fit.cc
@@ -170,10 +170,11 @@ void runRndFits(ConfigurationInfo* cfgInfo, bool useMinos, bool hesse, int maxIt
   else {
     cout << "MINIMUM LIKELIHOOD FROM " << minFitTag << " of " << numRnd << " RANDOM PRODUCTION PARS = " << minLL << endl;
     gSystem->Exec(Form("cp %s_%d.fit %s.fit", fitName.data(), minFitTag, fitName.data()));
-    if( seedfile.size() != 0 )
+    if( seedfile.size() != 0 ){
       string seedfileBaseName = seedfile.substr(0, seedfile.find_last_of("."));
       string seedfileExtension = seedfile.substr(seedfile.find_last_of("."));
       gSystem->Exec(Form("cp %s_%d%s %s", seedfileBaseName.data(), minFitTag, seedfileExtension.data(), seedfile.data()));
+    }
   }
 }
 

--- a/src/programs/AmplitudeAnalysis/fitMPI/fitMPI.cc
+++ b/src/programs/AmplitudeAnalysis/fitMPI/fitMPI.cc
@@ -168,7 +168,10 @@ void runRndFits(ConfigurationInfo* cfgInfo, bool useMinos, bool hesse, int maxIt
 	 ati.finalizeFit(to_string(i));
 
          if( seedfile.size() != 0 && !fitFailed ){
-            string seedfile_rand = seedfile + Form("_%d.txt", i);
+            string seedfileBaseName = seedfile.substr(0, seedfile.find_last_of("."));
+            string seedfileExtension = seedfile.substr(seedfile.find_last_of("."));
+
+            string seedfile_rand = seedfileBaseName + Form("_%d%s", i, seedfileExtension.data());
             ati.fitResults()->writeSeed( seedfile_rand );
          }
 
@@ -187,8 +190,11 @@ void runRndFits(ConfigurationInfo* cfgInfo, bool useMinos, bool hesse, int maxIt
       else {
          cout << "MINIMUM LIKELIHOOD FROM " << minFitTag << " of " << numRnd << " RANDOM PRODUCTION PARS = " << minLH << endl;
          gSystem->Exec(Form("cp %s_%d.fit %s.fit", fitName.data(), minFitTag, fitName.data()));
-         if( seedfile.size() != 0 )
-            gSystem->Exec(Form("cp %s_%d.txt %s.txt", seedfile.data(), minFitTag, seedfile.data()));
+         if( seedfile.size() != 0 ) {
+            string seedfileBaseName = seedfile.substr(0, seedfile.find_last_of("."));
+            string seedfileExtension = seedfile.substr(seedfile.find_last_of("."));
+            gSystem->Exec(Form("cp %s_%d%s %s", seedfileBaseName.data(), minFitTag, seedfileExtension.data(), seedfile.data()));
+         }
       }
    }
 
@@ -281,7 +287,10 @@ void runParScan(ConfigurationInfo* cfgInfo, bool useMinos, bool hesse, int maxIt
 
          ati.finalizeFit(to_string(i));
          if( seedfile.size() != 0 && !fitFailed ){
-            string seedfile_scan = seedfile + Form("_scan_%d.dat", i);
+            string seedfileBaseName = seedfile.substr(0, seedfile.find_last_of("."));
+            string seedfileExtension = seedfile.substr(seedfile.find_last_of("."));
+
+            string seedfile_scan = seedfileBaseName + Form("_scan_%d%s", i, seedfileExtension.data());
             ati.fitResults()->writeSeed( seedfile_scan );
          }
       }
@@ -414,6 +423,16 @@ int main( int argc, char* argv[] ){
    AmpToolsInterface::registerDataReader( DataReaderMPI<ROOTDataReaderWithTCut>() );
    AmpToolsInterface::registerDataReader( DataReaderMPI<ROOTDataReaderTEM>() );
    AmpToolsInterface::registerDataReader( DataReaderMPI<FSRootDataReader>() );
+
+   // normalize seedFile file extension if not already set by user
+   if (seedfile.size() != 0){
+      if (seedfile.find(".") == string::npos) seedfile += ".txt"; 
+      else{
+         // this ensures the file has an extension for cases like "./my_seed_file" 
+         string fileExtension = seedfile.substr(seedfile.find_last_of("."));
+         if (fileExtension.find("/") != string::npos) seedfile += ".txt";
+      }
+   }
 
    if(noFit)
       getLikelihood(cfgInfo);


### PR DESCRIPTION
The seedfile is treated differently depending on whether single or multiple fits are requested. For example, 
`fit -c amp.cfg -s my_seedfile.txt` will correctly produce `my_seedfile.txt`
`fit -c amp.cfg -s my_seedfile.txt -r 2` produces `my_seedfile.txt_0.txt` `my_seedfile.txt_1.txt`
Conversely,
`fit -c amp.cfg -s my_seedfile` produces `my_seedfile` without an extension.

These commits will add `.txt` to the seedfile unless an extension is already in the name and fixes the duplicate extensions bug when running multiple fits.