### PR TITLE
Vecps code maintenance

### DIFF
--- a/src/libraries/AMPTOOLS_AMPS/OmegaDalitz.cc
+++ b/src/libraries/AMPTOOLS_AMPS/OmegaDalitz.cc
@@ -10,7 +10,7 @@
 
 #include "IUAmpTools/Kinematics.h"
 #include "AMPTOOLS_AMPS/OmegaDalitz.h"
-#include "AMPTOOLS_AMPS/omegapiAngles.h"
+#include "AMPTOOLS_AMPS/vecPsAngles.h"
 
 OmegaDalitz::OmegaDalitz( const vector< string >& args ) :
 UserAmplitude< OmegaDalitz >( args )

--- a/src/libraries/AMPTOOLS_AMPS/Vec_ps_moment.cc
+++ b/src/libraries/AMPTOOLS_AMPS/Vec_ps_moment.cc
@@ -19,7 +19,7 @@ Modified by: Kevin Scheuer
 #include "IUAmpTools/Kinematics.h"
 #include "AMPTOOLS_AMPS/Vec_ps_moment.h"
 #include "AMPTOOLS_AMPS/wignerD.h"
-#include "AMPTOOLS_AMPS/omegapiAngles.h"
+#include "AMPTOOLS_AMPS/vecPsAngles.h"
 
 Vec_ps_moment::Vec_ps_moment( const vector< string >& args ) :
   UserAmplitude< Vec_ps_moment >( args )

--- a/src/libraries/AMPTOOLS_AMPS/Vec_ps_moment.cc
+++ b/src/libraries/AMPTOOLS_AMPS/Vec_ps_moment.cc
@@ -176,29 +176,31 @@ Vec_ps_moment::calcUserVars( GDouble** pKin, GDouble* userVars ) const {
   TLorentzVector Gammap = beam + target;
 
   // Calculate decay angles in helicity frame (same for all vectors)
-  vector <double> locthetaphi = getomegapiAngles(eps.Phi(), vec, X, beam, Gammap);
+  vector <double> xDecayAngles = getXDecayAngles(eps.Phi(), beam, Gammap, X, vec);
 
   // Calculate vector decay angles (unique for each vector)
-  vector <double> locthetaphih;
+  vector <double> vectorDecayAngles;
   if(m_3pi) 
   {
-    locthetaphih = getomegapiAngles(vec_daught1, vec, X, Gammap, vec_daught2);
+    vectorDecayAngles = getVectorDecayAngles( Gammap, X, vec,
+                                              vec_daught1, vec_daught2);
   }
   else 
   {
-    locthetaphih = getomegapiAngles(vec_daught1, vec, X, Gammap, TLorentzVector(0,0,0,0));
+    vectorDecayAngles = getVectorDecayAngles(Gammap, X, vec,
+                                        vec_daught1, TLorentzVector(0,0,0,0));
   }
     
   // the theta angles need to be in degrees for the wignerDSmall function
-  GDouble theta = locthetaphi[0] * 180.0 / TMath::Pi();
-  GDouble thetaH = locthetaphih[0] * 180.0 / TMath::Pi();
+  GDouble theta = xDecayAngles[0] * 180.0 / TMath::Pi();
+  GDouble thetaH = vectorDecayAngles[0] * 180.0 / TMath::Pi();
 
   // simply label the phi angles for easier reading
-  GDouble phi = locthetaphi[1];
-  GDouble phiH = locthetaphih[1];
+  GDouble phi = xDecayAngles[1];
+  GDouble phiH = vectorDecayAngles[1];
 
   // polarized components need cos(2Phi) and sin(2Phi), which take angles in radians
-  GDouble prodAngle = locthetaphi[2];
+  GDouble prodAngle = xDecayAngles[2];
   GDouble cos2prodAngle = TMath::Cos(2*prodAngle);
   GDouble sin2prodAngle = TMath::Sin(2*prodAngle);
 

--- a/src/libraries/AMPTOOLS_AMPS/Vec_ps_refl.cc
+++ b/src/libraries/AMPTOOLS_AMPS/Vec_ps_refl.cc
@@ -18,54 +18,52 @@
 
 #include "UTILITIES/BeamProperties.h"
 
+// Function to check if a string is a valid number
+static bool isValidNumber(const string& argInput, double &value){
+    char* end = nullptr;
+    errno = 0;  // reset global error
+    value = std::strtod(argInput.c_str(), &end);
+
+    // Check if 
+    // (1) no conversion was performed 
+    // (2) there are leftover characters
+    // (3) an overflow/underflow occurred   
+    if(end == argInput.c_str() || *end != '\0' || errno != 0) {
+        return false;  // not a valid number
+    }
+    // If end points to the end of string, it's fully numeric
+    return true;
+}
+
+static double parseValidatedNumber(const string& label, const string& argInput){
+    double tmpValue = 0.0;
+    if(!isValidNumber(argInput, tmpValue)){
+      throw std::invalid_argument("Vec_ps_refl: invalid " + label + ": " + argInput);
+    }
+    return tmpValue;
+}
+
+
 Vec_ps_refl::Vec_ps_refl( const vector< string >& args ) :
-UserAmplitude< Vec_ps_refl >( args )
-{
-  //assert( args.size() == 11 );
-  
-  
-  m_j = atoi( args[0].c_str() ); // resonance spin J
-  m_m = atoi( args[1].c_str() ); // spin projection (Lambda)
-  m_l = atoi( args[2].c_str() ); // partial wave L
-  m_r = atoi( args[3].c_str() ); // real (+1) or imaginary (-1)
-  m_s = atoi( args[4].c_str() ); // sign for polarization in amplitude
-
-  // default polarization information stored in tree
-  m_polInTree = true;
-
-  // default is 2-body vector decay (set flag in config file for omega->3pi)
-  m_3pi = false; 
+UserAmplitude< Vec_ps_refl >( args ){
 
   // 5 possibilities to initialize this amplitude:
-  // (with <J>: total spin, <m>: spin projection, <l>: partial wave, <r>: +1/-1 for real/imaginary part; <s>: +1/-1 sign in P_gamma term)
-
-  // loop over any additional amplitude arguments to change defaults
-  for(uint ioption=5; ioption<args.size(); ioption++) {
-	  TString option = args[ioption].c_str();
-
-	  // polarization provided in configuration file
-	  if(ioption==5 && option.IsFloat()) {
-		  m_polInTree = false;
-		  polAngle = atof(args[5].c_str());
-	  
-		  TString polOption = args[6].c_str();
-		  if(polOption.IsFloat()) polFraction = atof(polOption.Data());
-		  else if(polOption.Contains(".root")) {
-			  polFraction = 0.;
-			  TFile* f = new TFile( polOption );
-			  polFrac_vs_E = (TH1D*)f->Get( args[7].c_str() );
-			  assert( polFrac_vs_E != NULL );
-		  }
-		  else {
-			  cout << "ERROR: Vec_ps_refl beam polarization not set" <<endl;
-			  assert(0);
-		  }
-	  }
-
-	  // other options should be strings
-	  if(option.EqualTo("omega3pi")) m_3pi = true;
-
-  }
+  // <J>: total spin, 
+  // <m>: spin projection, 
+  // <l>: partial wave, 
+  // <r>: +1/-1 for real/imaginary part; 
+  // <s>: +1/-1 sign in P_gamma term
+  
+  // Resonance spin J
+  m_j = static_cast<int>(parseValidatedNumber("J", args[0])); 
+  // Spin projection (Lambda)
+  m_m = static_cast<int>(parseValidatedNumber("M", args[1])); 
+  // Partial wave L
+  m_l = static_cast<int>(parseValidatedNumber("L", args[2])); 
+  // Real (+1) or imaginary (-1)
+  m_r = static_cast<int>(parseValidatedNumber("Re/Im", args[3])); 
+  // Sign for polarization in amplitude
+  m_s = static_cast<int>(parseValidatedNumber("P_gamma sign", args[4])); 
 
   // make sure values are reasonable
   assert( abs( m_m ) <= m_j );
@@ -75,11 +73,44 @@ UserAmplitude< Vec_ps_refl >( args )
   // m_s = +1 for 1 + Pgamma
   // m_s = -1 for 1 - Pgamma
   assert( abs( m_s ) == 1 );
-  
+
+  // Default polarization information stored in tree
+  m_polInTree = true;
+
+  // Default is 2-body vector decay (set flag in config file for omega->3pi)
+  m_3pi = false;
+
+  // Loop over any additional amplitude arguments to change defaults
+  for(uint ioption=5; ioption<args.size(); ioption++) {
+	  TString option = args[ioption].c_str();
+    // Polarization provided in configuration file
+    if(ioption==5){
+      m_polInTree = false;
+
+      polAngle = parseValidatedNumber("polarization angle", args[5]);    
+
+      TString polOption = args[6].c_str();
+      if(polOption.Contains(".root")){
+        polFraction = 0.0;
+        TFile* f = new TFile(polOption);
+        polFrac_vs_E = (TH1D*)f->Get(args[7].c_str());
+        if(polFrac_vs_E  != nullptr ){
+          throw std::runtime_error(
+            "Vec_ps_refl ERROR: Could not find histogram '" + args[7] +
+            "' in file " + std::string(polOption.Data()));
+        }
+      }
+      else{
+        polFraction = parseValidatedNumber("polarization fraction", args[6]);
+      }
+    }
+    // Check for omega->3pi option
+	  if(option.EqualTo("omega3pi")) m_3pi = true;
+  }  
 }
 
 void
-Vec_ps_refl::calcUserVars( GDouble** pKin, GDouble* userVars ) const {
+Vec_ps_refl::calcUserVars( GDouble** pKin, GDouble* userVars ) const{
 
   TLorentzVector beam;
   TVector3 eps;
@@ -87,37 +118,41 @@ Vec_ps_refl::calcUserVars( GDouble** pKin, GDouble* userVars ) const {
   GDouble beam_polAngle;
 
   if(m_polInTree){
-    beam.SetPxPyPzE( 0., 0., pKin[0][0], pKin[0][0]);
-    eps.SetXYZ(pKin[0][1], pKin[0][2], 0.); // beam polarization vector;
+    beam.SetPxPyPzE( 0.0, 0.0, pKin[0][0], pKin[0][0]);
+    eps.SetXYZ(pKin[0][1], pKin[0][2], 0.0); // beam polarization vector;
 
     beam_polFraction = eps.Mag();
-    beam_polAngle = eps.Phi()*TMath::RadToDeg();
+    beam_polAngle = eps.Phi();
   }
-  else {
+  else{
     beam.SetPxPyPzE( pKin[0][1], pKin[0][2], pKin[0][3], pKin[0][0] );
     beam_polAngle = polAngle;
-    
-    if(polFraction > 0.) { // for fitting with fixed polarization
+
+    if(polFraction > 0.0){ // for fitting with fixed polarization
 	    beam_polFraction = polFraction;
     }
-    else { // for fitting with polarization vs E_gamma from input histogram 
+    else{ // for fitting with polarization vs E_gamma from input histogram 
 	    int bin = polFrac_vs_E->GetXaxis()->FindBin(pKin[0][0]);
 	    if (bin == 0 || bin > polFrac_vs_E->GetXaxis()->GetNbins()){
-		    beam_polFraction = 0.;
-	    } else 
+		    beam_polFraction = 0.0;
+	    } else
 		    beam_polFraction = polFrac_vs_E->GetBinContent(bin);
     }
   }
   
-  TLorentzVector recoil ( pKin[1][1], pKin[1][2], pKin[1][3], pKin[1][0] ); 
+  TLorentzVector recoil( pKin[1][1], pKin[1][2], pKin[1][3], pKin[1][0] ); 
 
-  // common vector and pseudoscalar P4s
-  TLorentzVector ps(pKin[2][1], pKin[2][2], pKin[2][3], pKin[2][0]); // 1st after proton
-  TLorentzVector vec, vec_daught1, vec_daught2; // compute for each final state below 
+  // Fill in four-vectors for final state particles
+  // 1st after proton is always the pseudoscalar meson
+  TLorentzVector ps(pKin[2][1], pKin[2][2], pKin[2][3], pKin[2][0]); 
+  // Compute vector meson from its decay products
+  // Make sure the order of daughters is correct in the config file!
+  TLorentzVector vec, vec_daught1, vec_daught2; 
 
-  // omega ps proton, omega -> 3pi (6 particles)
-  // omega pi- Delta++, omega -> 3pi (7 particles)
-  if(m_3pi) {
+
+  if(m_3pi){
+    // Omega ps proton, omega -> 3pi (6 particles)
+    // Omega pi- Delta++, omega -> 3pi (7 particles)
 	  TLorentzVector pi0(pKin[3][1], pKin[3][2], pKin[3][3], pKin[3][0]);
 	  TLorentzVector pip(pKin[4][1], pKin[4][2], pKin[4][3], pKin[4][0]);
 	  TLorentzVector pim(pKin[5][1], pKin[5][2], pKin[5][3], pKin[5][0]);
@@ -125,10 +160,10 @@ Vec_ps_refl::calcUserVars( GDouble** pKin, GDouble* userVars ) const {
 	  vec_daught1 = pip;
 	  vec_daught2 = pim;
   }
-  else {
-	  // omega ps proton, omega -> pi0 g (4 particles)
-	  // omega pi- Delta++, omega -> pi0 g (5 particles)
-	  
+  else{
+	  // Omega ps proton, omega -> pi0 g (4 particles)
+	  // Omega pi- Delta++, omega -> pi0 g (5 particles)
+
 	  // (vec 2-body) ps proton, vec 2-body -> pipi, KK (5 particles)
 	  // (vec 2-body) pi- Delta++, vec 2-body -> pipi, KK (6 particles)
 	  // (vec 2-body) K+ Lambda, vec 2-body -> Kpi (6 particles)
@@ -137,75 +172,78 @@ Vec_ps_refl::calcUserVars( GDouble** pKin, GDouble* userVars ) const {
 	  vec = vec_daught1 + vec_daught2;
   }
 
-  // final meson system P4
+  // Final meson system P4
   TLorentzVector X = vec + ps;
 
-  //////////////////////// Boost Particles and Get Angles//////////////////////////////////
+  ///////////////// Boost Particles and Get Angles/////////////////////
 
   TLorentzVector target(0,0,0,0.938);
-  //Helicity coordinate system
-  TLorentzVector Gammap = beam + target;
+  // Helicity coordinate system
+  TLorentzVector beamP = beam + target;
 
-  // Calculate decay angles in helicity frame (same for all vectors)
-  // set beam polarization angle to 0 degrees; apply diamond orientation in calcAmplitude
-  vector <double> locthetaphi = getomegapiAngles(0, vec, X, beam, Gammap);
+  // Calculate decay angles for X in helicity frame (same for all vectors)
+  // Change getXDecayAngles to get Gottfried-Jackson angles if needed
+  // Note: it also calculates the production angle
+  vector <double> xDecayAngles = getXDecayAngles( beam_polAngle, beam, beamP, X, vec);
 
   // Calculate vector decay angles (unique for each vector)
-  vector <double> locthetaphih;
-  if(m_3pi) locthetaphih = getomegapiAngles(vec_daught1, vec, X, Gammap, vec_daught2);
-  else locthetaphih = getomegapiAngles(vec_daught1, vec, X, Gammap, TLorentzVector(0,0,0,0));
+  vector <double> vectorDecayAngles;
+  if(m_3pi){
+    vectorDecayAngles = getVectorDecayAngles( beamP, X, vec,
+                                              vec_daught1, vec_daught2);
+  }
+  else{
+    vectorDecayAngles = getVectorDecayAngles( beamP, X, vec,
+                                        vec_daught1, TLorentzVector(0,0,0,0));
+  }
 
-
-  GDouble cosTheta = TMath::Cos(locthetaphi[0]);
-  GDouble Phi = locthetaphi[1];
-  GDouble cosThetaH = TMath::Cos(locthetaphih[0]);
-  GDouble PhiH = locthetaphih[1];
-  GDouble prod_angle = locthetaphi[2];
-  GDouble MX = X.M();
-  GDouble MVec = vec.M();
-  GDouble MPs = ps.M();
+  GDouble cosTheta = TMath::Cos(xDecayAngles[0]);
+  GDouble phi = xDecayAngles[1];
+  GDouble prod_angle = xDecayAngles[2]; // bigPhi
+  GDouble cosThetaH = TMath::Cos(vectorDecayAngles[0]);
+  GDouble phiH = vectorDecayAngles[1];
+  GDouble m_X = X.M();
+  GDouble m_vec = vec.M();
+  GDouble m_ps = ps.M();
 
   complex <GDouble> amplitude(0,0);
   complex <GDouble> i(0,1);
 
   for (int lambda = -1; lambda <= 1; lambda++) { // sum over vector helicity
 	  GDouble hel_amp = clebschGordan(m_l, 1, 0, lambda, m_j, lambda);
-	  amplitude += conj(wignerD( m_j, m_m, lambda, cosTheta, Phi )) * hel_amp * conj(wignerD( 1, lambda, 0, cosThetaH, PhiH ));
-  } 
-  
-  GDouble Factor = sqrt(1 + m_s * beam_polFraction);
-  
-  
-  complex< GDouble > zjm = 0;
-  
-  complex< GDouble > rotateY = polar( (GDouble)1., (GDouble)(-1.*(prod_angle + beam_polAngle*TMath::DegToRad())) ); // - -> + in prod_angle and polAngle summing
-  
-  
+          amplitude += conj(wignerD(m_j, m_m, lambda, cosTheta, phi)) *
+                       hel_amp * conj(wignerD(1, lambda, 0, cosThetaH, phiH));
+  }
+
+  GDouble factor = sqrt(1 + m_s * beam_polFraction);
+  complex <GDouble> zjm = 0;
+  // - -> + in prod_angle
+  complex <GDouble> rotateY = polar((GDouble)1., (GDouble)(-1. * prod_angle ));  
+
   if (m_r == 1)
 	  zjm = real(amplitude * rotateY);
   if (m_r == -1) 
 	  zjm = i*imag(amplitude * rotateY);
 
   // E852 Nozar thesis has sqrt(2*s+1)*sqrt(2*l+1)*F_l(p_omega)*sqrt(omega)
-  double kinFactor = barrierFactor(MX, m_l, MVec, MPs);
+  double kinFactor = barrierFactor(m_X, m_l, m_vec, m_ps);
   //kinFactor *= sqrt(3.) * sqrt(2.*m_l + 1.);
-  Factor *= kinFactor;
+  factor *= kinFactor;
 
-  userVars[uv_ampRe] = ( Factor * zjm ).real();
-  userVars[uv_ampIm] = ( Factor * zjm ).imag();
+  userVars[uv_ampRe] = ( factor * zjm ).real();
+  userVars[uv_ampIm] = ( factor * zjm ).imag();
 
   return;
 }
 
 
-////////////////////////////////////////////////// Amplitude Calculation //////////////////////////////////
+/////////////////////// Amplitude Calculation //////////////////////////
 
 complex< GDouble >
 Vec_ps_refl::calcAmplitude( GDouble** pKin, GDouble* userVars ) const
 {
   return complex< GDouble >( userVars[uv_ampRe], userVars[uv_ampIm] );
 }
-
 
 void Vec_ps_refl::updatePar( const AmpParameter& par ){
 

--- a/src/libraries/AMPTOOLS_AMPS/Vec_ps_refl.cc
+++ b/src/libraries/AMPTOOLS_AMPS/Vec_ps_refl.cc
@@ -13,7 +13,7 @@
 #include "AMPTOOLS_AMPS/Vec_ps_refl.h"
 #include "AMPTOOLS_AMPS/clebschGordan.h"
 #include "AMPTOOLS_AMPS/wignerD.h"
-#include "AMPTOOLS_AMPS/omegapiAngles.h"
+#include "AMPTOOLS_AMPS/vecPsAngles.h"
 #include "AMPTOOLS_AMPS/barrierFactor.h"
 
 #include "UTILITIES/BeamProperties.h"

--- a/src/libraries/AMPTOOLS_AMPS/omegapiAngles.cc
+++ b/src/libraries/AMPTOOLS_AMPS/omegapiAngles.cc
@@ -9,7 +9,10 @@
 #include "TLorentzRotation.h"
 #include "TMath.h"
 #include "omegapiAngles.h"
+#include "IUAmpTools/AmpToolsInterface.h"
+#include "IUAmpTools/report.h"
 
+static const char* kModule = "omegapiAngles";
 
 vector <double> getVectorDecayAngles( const TLorentzVector& beamPLab,
                                       const TLorentzVector& particleXLab,
@@ -142,10 +145,11 @@ vector<double> getXDecayAngles( double polAngle,
 
     // Compute the production angle (bigPhi) between the polarization 
     // angle and the normal to the production plane
-    // But first, make sure the polarization angle is in radians
+    // But first, make sure the polarization angle is in radians  
     static bool warned = false; // only warn once
     if(!warned && (fabs(polAngle) > 2 * TMath::Pi())){
-      cerr << "[Notice] getXDecayAngles(): polAngle = " << polAngle
+      report( NOTICE, kModule )
+           << " getXDecayAngles(): polAngle = " << polAngle
            << " appears to be in degrees. Converting to radians."
            << endl;
       polAngle = DEG_TO_RAD * polAngle;

--- a/src/libraries/AMPTOOLS_AMPS/omegapiAngles.h
+++ b/src/libraries/AMPTOOLS_AMPS/omegapiAngles.h
@@ -1,4 +1,33 @@
+// The purpose of getVectorDecayAngles() is to return the helicity angles 
+// of the normal to the decay plane of the vector parent particle.
+// This function also returns the variable lambda used in the 
+// omega->3pi decay amplitude.
 
+// The purpose of getXDecayAngles() is to return the helicity angles of 
+// particle X in the reaction gamma + p -> X + p.
+// This function also returns the angle between the polarization
+// vector and the normal to the production plane of particle X.
+// Both functions return a vector of doubles containing the polar 
+// angle theta, the azimuthal angle phi, and either lambda or bigPhi 
+// The angles are calculated in the helicity frame of the parent 
+// The code uses b1->omega pi and omega->3pi as an example,
+// but can be used for any vector decay.
+
+// For a two particle decay, the function arguments are the lab 
+// frame TLorentzVectors of: the daughter particle, the parent 
+// particle, the inverse of the X-axis and the reference Z-axis.
+
+// For a three particle decay, the function arguments are the same 
+// with the addition of a second daughter particle.
+// Note that in this case the normal to the decay plane is calculated as
+// the cross product between the first daughter and the second daughter vectors.
+
+// The function could also return the decay angles in
+// other frames when called with the appropriate argument change.
+// Gottfried-Jackson (commented in code): The z-axis is equal to the
+//        direction of the incoming beam in the particle X rest frame.
+// Adair RF: The z-axis is equal to the direction of the incoming beam
+//        in the center of mass system.
 #if !defined(OMEGAPIANGLES)
 #define OMEGAPIANGLES
 
@@ -13,8 +42,18 @@
 using std::complex;
 using namespace std;
 
-vector <double> getomegapiAngles(TLorentzVector daughter, TLorentzVector parent, TLorentzVector InverseOfX, TLorentzVector rf, TLorentzVector seconddaughter);
+constexpr double DEG_TO_RAD = TMath::Pi() / 180.0;
 
-vector <double> getomegapiAngles(double polAngle, TLorentzVector daughter, TLorentzVector parent, TLorentzVector InverseOfX, TLorentzVector rf);
+vector <double> getVectorDecayAngles( const TLorentzVector& beamPLab,
+                                      const TLorentzVector& particleXLab,
+                                      const TLorentzVector& parentLab, 
+                                      const TLorentzVector& firstDaughterLab, 
+                                      const TLorentzVector& secondDaughterLab);
+
+vector<double> getXDecayAngles( double polAngle, 
+                                const TLorentzVector& beamLab, 
+                                const TLorentzVector& beamPLab,
+                                const TLorentzVector& particleXLab,
+                                const TLorentzVector& daughterLab);
 
 #endif

--- a/src/libraries/AMPTOOLS_AMPS/omegapi_amplitude.cc
+++ b/src/libraries/AMPTOOLS_AMPS/omegapi_amplitude.cc
@@ -19,7 +19,7 @@
 #include "clebschGordan.h"
 #include "wignerD.h"
 #include "breakupMomentum.h"
-#include "omegapiAngles.h"
+#include "vecPsAngles.h"
 
 #include <cmath>
 #include <complex>

--- a/src/libraries/AMPTOOLS_AMPS/omegapi_amplitude.cc
+++ b/src/libraries/AMPTOOLS_AMPS/omegapi_amplitude.cc
@@ -115,17 +115,19 @@ omegapi_amplitude::calcUserVars( GDouble** pKin, GDouble* userVars ) const
 	}
 
   //Calculate decay angles in helicity frame
-  vector <double> locthetaphi = getomegapiAngles(0.0, omega, X, beam, Gammap);
+  vector <double> xDecayAngles = getXDecayAngles( polAngle, beam, Gammap, X, omega);
 
-  vector <double> locthetaphih = getomegapiAngles(rhos_pip, omega, X, Gammap, rhos_pim);
+  vector <double> vectorDecayAngles = getVectorDecayAngles( Gammap, X, omega,
+                                                            rhos_pip, rhos_pim);
 
-  userVars[uv_cosTheta] = TMath::Cos(locthetaphi[0]);
-  userVars[uv_Phi] = locthetaphi[1];
 
-  userVars[uv_cosThetaH] = TMath::Cos(locthetaphih[0]);
-  userVars[uv_PhiH] = locthetaphih[1];
+  userVars[uv_cosTheta] = TMath::Cos(xDecayAngles[0]);
+  userVars[uv_Phi] = xDecayAngles[1];
 
-  userVars[uv_prod_angle] = locthetaphi[2];
+  userVars[uv_prod_angle] = xDecayAngles[2];
+
+  userVars[uv_cosThetaH] = TMath::Cos(vectorDecayAngles[0]);
+  userVars[uv_PhiH] = vectorDecayAngles[1];
 
   userVars[uv_Pgamma] = Pgamma;
   

--- a/src/libraries/AMPTOOLS_AMPS/vecPsAngles.cc
+++ b/src/libraries/AMPTOOLS_AMPS/vecPsAngles.cc
@@ -8,11 +8,11 @@
 #include "TLorentzVector.h"
 #include "TLorentzRotation.h"
 #include "TMath.h"
-#include "omegapiAngles.h"
+#include "vecPsAngles.h"
 #include "IUAmpTools/AmpToolsInterface.h"
 #include "IUAmpTools/report.h"
 
-static const char* kModule = "omegapiAngles";
+static const char* kModule = "vecPsAngles";
 
 vector <double> getVectorDecayAngles( const TLorentzVector& beamPLab,
                                       const TLorentzVector& particleXLab,
@@ -151,6 +151,7 @@ vector<double> getXDecayAngles( double polAngle,
       report( NOTICE, kModule )
            << " getXDecayAngles(): polAngle = " << polAngle
            << " appears to be in degrees. Converting to radians."
+           << " This message will only be shown once."
            << endl;
       polAngle = DEG_TO_RAD * polAngle;
       warned = true;

--- a/src/libraries/AMPTOOLS_AMPS/vecPsAngles.h
+++ b/src/libraries/AMPTOOLS_AMPS/vecPsAngles.h
@@ -28,8 +28,8 @@
 //        direction of the incoming beam in the particle X rest frame.
 // Adair RF: The z-axis is equal to the direction of the incoming beam
 //        in the center of mass system.
-#if !defined(OMEGAPIANGLES)
-#define OMEGAPIANGLES
+#if !defined(VECPSANGLES)
+#define VECPSANGLES
 
 #include <string>
 #include <complex>

--- a/src/libraries/AMPTOOLS_DATAIO/OmegaPiPlotGenerator.cc
+++ b/src/libraries/AMPTOOLS_DATAIO/OmegaPiPlotGenerator.cc
@@ -10,7 +10,7 @@
 #include "TLorentzVector.h"
 #include "TLorentzRotation.h"
 
-#include "AMPTOOLS_AMPS/omegapiAngles.h"
+#include "AMPTOOLS_AMPS/vecPsAngles.h"
 
 //#include <cmath>
 //#include <complex>

--- a/src/libraries/AMPTOOLS_DATAIO/OmegaPiPlotGenerator.cc
+++ b/src/libraries/AMPTOOLS_DATAIO/OmegaPiPlotGenerator.cc
@@ -101,16 +101,16 @@ OmegaPiPlotGenerator::projectEvent( Kinematics* kin, const string& reactionName 
   TLorentzVector Gammap = beam + target;
  
   //Calculate decay angles in helicity frame
-  vector <double> locthetaphi = getomegapiAngles(polAngle, omega, X, beam, Gammap);
+  vector <double> xDecayAngles = getXDecayAngles(polAngle, beam, Gammap, X, omega);
 
-  vector <double> locthetaphih = getomegapiAngles(rhos_pip, omega, X, Gammap, rhos_pim);
+  vector <double> vectorDecayAngles = getVectorDecayAngles(Gammap, X, omega, rhos_pip, rhos_pim);
 
-   GDouble cosTheta = TMath::Cos(locthetaphi[0]);
-   GDouble Phi = locthetaphi[1];
-   GDouble cosThetaH = TMath::Cos(locthetaphih[0]);
-   GDouble PhiH = locthetaphih[1];
-   GDouble prod_angle = locthetaphi[2];
-   GDouble lambda = locthetaphih[2];
+   GDouble cosTheta = TMath::Cos(xDecayAngles[0]);
+   GDouble Phi = xDecayAngles[1];
+   GDouble prod_angle = xDecayAngles[2];
+   GDouble cosThetaH = TMath::Cos(vectorDecayAngles[0]);
+   GDouble PhiH = vectorDecayAngles[1];
+   GDouble lambda = vectorDecayAngles[2];
 
    // cout << "calls to fillHistogram go here" << endl;
    fillHistogram( kOmegaPiMass, b1_mass );

--- a/src/libraries/AMPTOOLS_DATAIO/VecPsPlotGenerator.cc
+++ b/src/libraries/AMPTOOLS_DATAIO/VecPsPlotGenerator.cc
@@ -7,6 +7,31 @@
 #include "IUAmpTools/Histogram1D.h"
 #include "IUAmpTools/Kinematics.h"
 
+// Function to check if a string is a valid number
+static bool isValidNumber(const string& argInput, double &value){
+    char* end = nullptr;
+    errno = 0;  // reset global error
+    value = std::strtod(argInput.c_str(), &end);
+
+    // Check if 
+    // (1) no conversion was performed 
+    // (2) there are leftover characters
+    // (3) an overflow/underflow occurred   
+    if(end == argInput.c_str() || *end != '\0' || errno != 0) {
+        return false;  // not a valid number
+    }
+    // If end points to the end of string, it's fully numeric
+    return true;
+}
+
+static double parseValidatedNumber(const string& label, const string& argInput){
+    double tmpValue = 0.0;
+    if(!isValidNumber(argInput, tmpValue)){
+      throw std::invalid_argument("Vec_ps_refl: invalid " + label + ": " + argInput);
+    }
+    return tmpValue;
+}
+
 /* Constructor to display FitResults */
 VecPsPlotGenerator::VecPsPlotGenerator( const FitResults& results, Option opt ) :
 PlotGenerator( results, opt )
@@ -23,25 +48,39 @@ PlotGenerator( )
 
 void VecPsPlotGenerator::createHistograms( ) {
   cout << " calls to bookHistogram go here" << endl;
-  
-   bookHistogram( kVecPsMass, new Histogram1D( 200, 0.6, 2., "MVecPs", "Invariant Mass of Vec+Ps [GeV]") );
-   bookHistogram( kCosTheta, new Histogram1D( 50, -1., 1., "CosTheta", "cos#theta" ) );
-   bookHistogram( kPhi, new Histogram1D( 50, -1*PI, PI, "Phi", "#phi [rad.]" ) );
-   bookHistogram( kCosThetaH, new Histogram1D( 50, -1., 1., "CosTheta_H", "cos#theta_H" ) );
-   bookHistogram( kPhiH, new Histogram1D( 50, -1*PI, PI, "Phi_H", "#phi_H [rad.]" ) );
-   bookHistogram( kProd_Ang, new Histogram1D( 50, -1*PI, PI, "Prod_Ang", "Prod_Ang [rad.]" ) );
-   bookHistogram( kt, new Histogram1D( 100, 0, 2.0 , "t", "-t" ) );
-   bookHistogram( kRecoilMass, new Histogram1D( 100, 0.9, 1.9 , "MRecoil", "Invariant Mass of Recoil [GeV]" ) );
-   bookHistogram( kProtonPsMass, new Histogram1D( 100, 0.9, 2.9, "MProtonPs", "Invariant Mass of proton and bachelor Ps [GeV]" ) );
-   bookHistogram( kRecoilPsMass, new Histogram1D( 100, 0.9, 2.9, "MRecoilPs", "Invariant Mass of recoil and bachelor Ps [GeV]" ) );
-   bookHistogram( kLambda, new Histogram1D( 110, 0.0, 1.1, "Lambda", "#lambda_{#omega}" ) );
-   bookHistogram( kDalitz, new Histogram2D( 100, -2., 2., 100, -2., 2., "Dalitz", "Dalitz XY" ) );
+
+  bookHistogram(kVecPsMass, new Histogram1D(200, 0.6, 2., "MVecPs",
+                 ";Invariant Mass of Vec+Ps [GeV]"));
+  bookHistogram(kCosTheta, new Histogram1D(50, -1., 1., "CosTheta",
+                 ";cos#theta"));
+  bookHistogram(kPhi, new Histogram1D(50, -PI, PI, "Phi", ";#phi [rad.]"));
+  bookHistogram(kCosThetaH, new Histogram1D(50, -1., 1., "CosTheta_H",
+                 ";cos#theta_H"));
+  bookHistogram(kPhiH, new Histogram1D(50, -PI, PI, "Phi_H", ";#phi_H [rad.]"));
+  bookHistogram(kProd_Ang, new Histogram1D(50, -PI, PI, "Prod_Ang",
+                 ";Prod_Ang (#Phi) [rad.]"));
+  bookHistogram(kt, new Histogram1D(100, 0, 2.0, "t", ";-t"));
+  bookHistogram(kRecoilMass, new Histogram1D(100, 0.9, 1.9, "MRecoil",
+                 ";Invariant Mass of Recoil [GeV]"));
+  bookHistogram(kProtonPsMass, new Histogram1D(100, 0.9, 2.9, "MProtonPs",
+                 ";Invariant Mass of proton and bachelor Ps [GeV]"));
+  bookHistogram(kRecoilPsMass, new Histogram1D(100, 0.9, 2.9, "MRecoilPs",
+                 ";Invariant Mass of recoil and bachelor Ps [GeV]"));
+  bookHistogram(kLambda, new Histogram1D(110, 0.0, 1.1, "Lambda",
+                 ";#lambda_{#omega}"));
+  bookHistogram(kDalitz, new Histogram2D(100, -2., 2., 100, -2., 2., "Dalitz",
+                 ";Dalitz X; Dalitz Y"));
+  bookHistogram(kPhi_ProdVsPhi, new Histogram2D(25, -PI, PI, 25, -PI, PI,
+                 "Phi_ProdVsPhi", ";#phi [rad.]; Prod_Ang (#Phi) [rad.]" ));
+  bookHistogram(kPhiOffsetVsPhi, new Histogram2D(25, -PI, PI, 25, -PI, PI,
+                 "PhiOffsetVsPhi",
+                 ";#phi [rad.]; Prod_Ang (#Phi) Uncorrected [rad.]" ));
 }
 
 void
 VecPsPlotGenerator::projectEvent( Kinematics* kin ){
 
-  // this function will make this class backwards-compatible with older versions
+  // This function will make this class backwards-compatible with older versions
   // (v0.10.x and prior) of AmpTools, but will not be able to properly obtain
   // the polariation plane in the lab when multiple orientations are used
   projectEvent( kin, "" );
@@ -53,55 +92,73 @@ VecPsPlotGenerator::projectEvent( Kinematics* kin, const string& reactionName ){
    //cout << "project event" << endl;
    TLorentzVector beam   = kin->particle( 0 );
    TLorentzVector recoil = kin->particle( 1 );
+   // 1st after proton is always the pseudoscalar (bachelor) meson
    TLorentzVector bach = kin->particle( 2 );
 
-   // default is 2-body vector decay (set flag in config file for omega->3pi)
+   // Default is 2-body vector decay (set flag in config file for omega->3pi)
    bool m_3pi = false;  
 
-   // min particle index for recoil sum
+   // Min particle index for recoil sum
    int min_recoil = 5; 
 
-   // check config file for optional parameters -- we assume here that the first amplitude in the list is a Vec_ps_refl amplitude
-   const vector< string > args = cfgInfo()->amplitudeList( reactionName, "", "" ).at(0)->factors().at(0);
-   for(uint ioption=5; ioption<args.size(); ioption++) {
-          TString option = args[ioption].c_str();
-	  if(option.EqualTo("omega3pi")) m_3pi = true;
+   
+   // Properly read polarization angle from config file if provided
+   double beam_polAngle=0;
+   // Check config file for optional parameters -- we assume here that the
+   // first amplitude in the list is a Vec_ps_refl amplitude or a Vec_ps_moment
+   const vector<string> args =
+       cfgInfo()->amplitudeList(reactionName, "", "").at(0)->factors().at(0);
+   for(uint ioption = 0; ioption < args.size(); ioption++){
+      TString option = args[ioption].c_str();
+      if(option.EqualTo("Vec_ps_moment")){
+      // Force the 3pi decay as it's currently the only one handled by it
+      m_3pi = true;
+      break;
+     }
+     else{
+       if(ioption == 6){
+         beam_polAngle = parseValidatedNumber("polarization angle", args[6]);
+       }
+       if(option.EqualTo("omega3pi")){
+         m_3pi = true;
+       }
+     }
    }
 
-   // if the amplitude is a moment, force the 3pi decay as it's currently the only one handled by it
-   const vector < string > momentArgs = cfgInfo()->amplitudeList( reactionName, "", "" ).at(0)->factors().at(0);
-   for (uint ioption=0; ioption<momentArgs.size(); ioption++) {
-          TString option = momentArgs[ioption].c_str();
-      if(option.EqualTo("Vec_ps_moment")) m_3pi = true;
-   }
-
-   TLorentzVector vec, vec_daught1, vec_daught2; // compute for each final state below 
+   // Compute vector meson from its decay products
+   // Make sure the order of daughters is correct in the config file!
+   TLorentzVector vec, vec_daught1, vec_daught2;  
    double dalitz_s, dalitz_t, dalitz_u, dalitz_d, dalitz_sc;
-   double dalitzx = 0;
-   double dalitzy = 0;
+   double dalitz_x = 0.0;
+   double dalitz_y = 0.0;
 
    if(m_3pi) {
-	  // omega ps proton, omega -> 3pi (6 particles)
-	  // omega pi- Delta++, omega -> 3pi (7 particles)
-          TLorentzVector pi0 = kin->particle( 3 );//omega's pi0
-          TLorentzVector pip = kin->particle( 4 );//pi-
-          TLorentzVector pim = kin->particle( 5 );//pi+
-          vec = pi0 + pip + pim;
-          vec_daught1 = pip;
-          vec_daught2 = pim;
+     // Omega ps proton, omega -> 3pi (6 particles)
+     // Omega pi- Delta++, omega -> 3pi (7 particles)
+     TLorentzVector pi0 = kin->particle( 3 );
+     TLorentzVector pip = kin->particle( 4 );
+     TLorentzVector pim = kin->particle( 5 );
+     vec = pi0 + pip + pim;
+     vec_daught1 = pip;
+     vec_daught2 = pim;
 	  min_recoil = 6;
 
 	  // Dalitz variables
-	  TLorentzVector p2 = pi0;
-	  TLorentzVector p3 = pip;
-	  TLorentzVector p4 = pim;
-	  dalitz_s = (p3+p4).M2();//s=M(pip pim)
-	  dalitz_t = (p2+p3).M2();//s=M(pip pi0)
-	  dalitz_u = (p2+p4).M2();//s=M(pim pi0)
-	  dalitz_d = 2*(p2+p3+p4).M()*( (p2+p3+p4).M() - ((2*0.13957018)+0.1349766) );
-	  dalitz_sc = (1/3.)*( (p2+p3+p4).M2() + ((2*(0.13957018*0.13957018))+(0.1349766*0.1349766)) );
-	  dalitzx = sqrt(3.)*(dalitz_t - dalitz_u)/dalitz_d;
-	  dalitzy = 3.*(dalitz_sc - dalitz_s)/dalitz_d;
+	  const auto& p2 = pi0;
+	  const auto& p3 = pip;
+	  const auto& p4 = pim;
+     double pdg_m_pi0 = 0.1349766;
+     double pdg_m_chargedPi = 0.13957018;
+     dalitz_s = (p3 + p4).M2();  // s=M(pip pim)
+     dalitz_t = (p2 + p3).M2();  // s=M(pip pi0)
+     dalitz_u = (p2 + p4).M2();  // s=M(pim pi0)
+     dalitz_d = 2 * (p2 + p3 + p4).M() *
+                ((p2 + p3 + p4).M() - ((2 * pdg_m_chargedPi) + pdg_m_pi0));
+     dalitz_sc = (1.0 / 3.0) * ((p2 + p3 + p4).M2() +
+                                ((2 * (pdg_m_chargedPi * pdg_m_chargedPi)) +
+                                 (pdg_m_pi0 * pdg_m_pi0)));
+     dalitz_x = sqrt(3.0) * (dalitz_t - dalitz_u) / dalitz_d;
+     dalitz_y = 3.0 * (dalitz_sc - dalitz_s) / dalitz_d;
 
    }
    else {
@@ -112,61 +169,68 @@ VecPsPlotGenerator::projectEvent( Kinematics* kin, const string& reactionName ){
 	  // (vec 2-body) pi- Delta++, vec 2-body -> pipi, KK (6 particles)
 	  // (vec 2-body) K+ Lambda, vec 2-body -> Kpi (6 particles)
 	  vec_daught1 = kin->particle( 3 );
-          vec_daught2 = kin->particle( 4 );
-          vec = vec_daught1 + vec_daught2;
+     vec_daught2 = kin->particle( 4 );
+     vec = vec_daught1 + vec_daught2;
 	  min_recoil = 5;
-	  dalitzx = 0.;
-	  dalitzy = 0.;
    }
 
-   // final meson system P4
+   // Final meson system P4
    TLorentzVector X = vec + bach;
 
    TLorentzVector proton_ps = recoil + bach;
    TLorentzVector recoil_ps = proton_ps;
-   for(uint i=min_recoil; i<kin->particleList().size(); i++) { 
-	// add mesons to recoil system (e.g. Delta or Lambda)
-	recoil += kin->particle(i);
-	recoil_ps += kin->particle(i);
+   for(uint i=min_recoil; i<kin->particleList().size(); i++){ 
+	   // Add mesons to recoil system (e.g. Delta or Lambda)
+	   recoil += kin->particle(i);
+	   recoil_ps += kin->particle(i);
    }
 
-   // set polarization angle to zero to see shift in Phi_Prod distributions 
-   double polAngle = 0;
    TLorentzVector target(0,0,0,0.938);
-
    // Helicity coordinate system
-   TLorentzVector Gammap = beam + target;
+   TLorentzVector beamP = beam + target;
 
-   // Calculate decay angles in helicity frame (same for all vectors)
-   vector <double> locthetaphi = getomegapiAngles(polAngle, vec, X, beam, Gammap);
+   // Calculate decay angles for X in helicity frame (same for all vectors)
+   // Change getXDecayAngles to get Gottfried-Jackson angles if needed
+   // Note: it also calculates the production angle
+   vector <double> xDecayAngles = getXDecayAngles( beam_polAngle, beam, beamP, X, vec);
+   // set polarization angle to zero to see shift in Phi_Prod distributions 
+   vector <double> xDecayAngles_offset = getXDecayAngles( 0, beam, beamP, X, vec);
 
    // Calculate vector decay angles (unique for each vector)
-   vector <double> locthetaphih;
-   if(m_3pi) locthetaphih = getomegapiAngles(vec_daught1, vec, X, Gammap, vec_daught2);
-   else locthetaphih = getomegapiAngles(vec_daught1, vec, X, Gammap, TLorentzVector(0,0,0,0));
+   vector <double> vectorDecayAngles;
+   if(m_3pi){
+    vectorDecayAngles = getVectorDecayAngles( beamP, X, vec,
+                                              vec_daught1, vec_daught2);
+   }
+   else{
+    vectorDecayAngles = getVectorDecayAngles( beamP, X, vec,
+                                        vec_daught1, TLorentzVector(0,0,0,0));
+   }
 
    double Mandt = fabs((target-recoil).M2());
    double recoil_mass = recoil.M();  
 
-   GDouble cosTheta = TMath::Cos(locthetaphi[0]);
-   GDouble Phi = locthetaphi[1];
-   GDouble cosThetaH = TMath::Cos(locthetaphih[0]);
-   GDouble PhiH = locthetaphih[1];
-   GDouble prod_angle = locthetaphi[2];
-   GDouble lambda = locthetaphih[2];
+   GDouble cosTheta = TMath::Cos(xDecayAngles[0]);
+   GDouble phi = xDecayAngles[1];
+   GDouble prod_angle = xDecayAngles[2]; // bigPhi
+   GDouble prod_angle_offset = xDecayAngles_offset[2]; // bigPhi not corrected
+   GDouble cosThetaH = TMath::Cos(vectorDecayAngles[0]);
+   GDouble phiH = vectorDecayAngles[1];
+   GDouble lambda = vectorDecayAngles[2];
 
    //cout << "calls to fillHistogram go here" << endl;
    fillHistogram( kVecPsMass, X.M() );
    fillHistogram( kCosTheta, cosTheta );
-   fillHistogram( kPhi, Phi );
+   fillHistogram( kPhi, phi );
    fillHistogram( kCosThetaH, cosThetaH );
-   fillHistogram( kPhiH, PhiH );
+   fillHistogram( kPhiH, phiH );
    fillHistogram( kProd_Ang, prod_angle );
    fillHistogram( kt, Mandt );
    fillHistogram( kRecoilMass, recoil_mass );
    fillHistogram( kProtonPsMass, proton_ps.M() );
    fillHistogram( kRecoilPsMass, recoil_ps.M() );
    fillHistogram( kLambda, lambda );
-   fillHistogram( kDalitz, dalitzx, dalitzy );
-
+   fillHistogram( kDalitz, dalitz_x, dalitz_y );
+   fillHistogram( kPhi_ProdVsPhi, phi, prod_angle );
+   fillHistogram( kPhiOffsetVsPhi, phi, prod_angle_offset );
 }

--- a/src/libraries/AMPTOOLS_DATAIO/VecPsPlotGenerator.cc
+++ b/src/libraries/AMPTOOLS_DATAIO/VecPsPlotGenerator.cc
@@ -1,7 +1,7 @@
 #include "TLorentzVector.h"
 #include "TLorentzRotation.h"
 
-#include "AMPTOOLS_AMPS/omegapiAngles.h"
+#include "AMPTOOLS_AMPS/vecPsAngles.h"
 
 #include "AMPTOOLS_DATAIO/VecPsPlotGenerator.h"
 #include "IUAmpTools/Histogram1D.h"

--- a/src/libraries/AMPTOOLS_DATAIO/VecPsPlotGenerator.h
+++ b/src/libraries/AMPTOOLS_DATAIO/VecPsPlotGenerator.h
@@ -17,7 +17,10 @@ class VecPsPlotGenerator : public PlotGenerator
 public:
   
   // create an index for different histograms
-  enum { kVecPsMass = 0, kCosTheta = 1, kPhi = 2, kCosThetaH = 3, kPhiH = 4, kProd_Ang = 5, kt = 6, kRecoilMass = 7, kProtonPsMass = 8, kRecoilPsMass = 9, kLambda = 10, kDalitz = 11,  kNumHists};
+  enum { kVecPsMass = 0, kCosTheta = 1, kPhi = 2, kCosThetaH = 3, kPhiH = 4, 
+         kProd_Ang = 5, kt = 6, kRecoilMass = 7, kProtonPsMass = 8, 
+         kRecoilPsMass = 9, kLambda = 10, kDalitz = 11, kPhi_ProdVsPhi = 12, 
+         kPhiOffsetVsPhi = 13, kNumHists};
 
   VecPsPlotGenerator( const FitResults& results, Option opt);
   VecPsPlotGenerator( const FitResults& results );

--- a/src/programs/AmplitudeAnalysis/vecps_plotter/vecps_plotter.cc
+++ b/src/programs/AmplitudeAnalysis/vecps_plotter/vecps_plotter.cc
@@ -146,9 +146,12 @@ int main(int argc, char* argv[]) {
         const vector<string> reflname = {"PosRefl", "NegRefl"};
 
         // loop over sum configurations (one for each of the individual
-        // contributions, and the combined sum of all)
+        // contributions [when irefl < reflname.size()], and the combined sum
+        // of all [when irefl == reflname.size()])
         for (unsigned int irefl = 0; irefl <= reflname.size(); irefl++) {
-            // loop over desired amplitudes
+            // loop over desired amplitudes (one for each of the individual
+            // contributions [when iamp < amphistname.size()], and the combined
+            // sum of all [when iamp == amphistname.size()])
             for (unsigned int iamp = 0; iamp <= amphistname.size(); iamp++) {
                 // turn all ampltiudes by default
                 for (unsigned int jamp = 0; jamp < amps.size(); jamp++) {

--- a/src/programs/AmplitudeAnalysis/vecps_plotter/vecps_plotter.cc
+++ b/src/programs/AmplitudeAnalysis/vecps_plotter/vecps_plotter.cc
@@ -1,369 +1,434 @@
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <string>
 #include <vector>
 
-#include "TClass.h"
-#include "TApplication.h"
-#include "TGClient.h"
-#include "TROOT.h"
-#include "TH1.h"
-#include "TStyle.h"
-#include "TClass.h"
-#include "TFile.h"
-#include "TMultiGraph.h"
-#include "TGraphErrors.h"
-
-#include "IUAmpTools/AmpToolsInterface.h"
-#include "IUAmpTools/FitResults.h"
-
-#include "AmpPlotter/PlotterMainWindow.h"
-#include "AmpPlotter/PlotFactory.h"
-
-#include "AMPTOOLS_DATAIO/VecPsPlotGenerator.h"
+#include "AMPTOOLS_AMPS/BreitWigner.h"
+#include "AMPTOOLS_AMPS/ComplexCoeff.h"
+#include "AMPTOOLS_AMPS/OmegaDalitz.h"
+#include "AMPTOOLS_AMPS/PhaseOffset.h"
+#include "AMPTOOLS_AMPS/Piecewise.h"
+#include "AMPTOOLS_AMPS/Uniform.h"
+#include "AMPTOOLS_AMPS/Vec_ps_moment.h"
+#include "AMPTOOLS_AMPS/Vec_ps_refl.h"
+#include "AMPTOOLS_DATAIO/FSRootDataReader.h"
 #include "AMPTOOLS_DATAIO/ROOTDataReader.h"
 #include "AMPTOOLS_DATAIO/ROOTDataReaderBootstrap.h"
 #include "AMPTOOLS_DATAIO/ROOTDataReaderTEM.h"
-#include "AMPTOOLS_DATAIO/FSRootDataReader.h"
-#include "AMPTOOLS_AMPS/BreitWigner.h"
-#include "AMPTOOLS_AMPS/Uniform.h"
-#include "AMPTOOLS_AMPS/Vec_ps_refl.h"
-#include "AMPTOOLS_AMPS/PhaseOffset.h"
-#include "AMPTOOLS_AMPS/ComplexCoeff.h"
-#include "AMPTOOLS_AMPS/Piecewise.h"
-#include "AMPTOOLS_AMPS/OmegaDalitz.h"
-#include "AMPTOOLS_AMPS/Vec_ps_moment.h"
-
-#include "MinuitInterface/MinuitMinimizationManager.h"
+#include "AMPTOOLS_DATAIO/VecPsPlotGenerator.h"
+#include "AmpPlotter/PlotFactory.h"
+#include "AmpPlotter/PlotterMainWindow.h"
+#include "IUAmpTools/AmpToolsInterface.h"
 #include "IUAmpTools/ConfigFileParser.h"
 #include "IUAmpTools/ConfigurationInfo.h"
+#include "IUAmpTools/FitResults.h"
+#include "MinuitInterface/MinuitMinimizationManager.h"
+#include "TApplication.h"
+#include "TClass.h"
+#include "TFile.h"
+#include "TGClient.h"
+#include "TGraphErrors.h"
+#include "TH1.h"
+#include "TMultiGraph.h"
+#include "TROOT.h"
+#include "TStyle.h"
 
 typedef VecPsPlotGenerator vecps_PlotGen;
 
-void atiSetup(){
-  
-  AmpToolsInterface::registerAmplitude( BreitWigner() );
-  AmpToolsInterface::registerAmplitude( Uniform() );
-  AmpToolsInterface::registerAmplitude( Vec_ps_refl() );
-  AmpToolsInterface::registerAmplitude( PhaseOffset() );
-  AmpToolsInterface::registerAmplitude( ComplexCoeff() );
-  AmpToolsInterface::registerAmplitude( Piecewise() );
-  AmpToolsInterface::registerAmplitude( OmegaDalitz() );
-  AmpToolsInterface::registerAmplitude( Vec_ps_moment() );
+void atiSetup() {
+    AmpToolsInterface::registerAmplitude(BreitWigner());
+    AmpToolsInterface::registerAmplitude(Uniform());
+    AmpToolsInterface::registerAmplitude(Vec_ps_refl());
+    AmpToolsInterface::registerAmplitude(PhaseOffset());
+    AmpToolsInterface::registerAmplitude(ComplexCoeff());
+    AmpToolsInterface::registerAmplitude(Piecewise());
+    AmpToolsInterface::registerAmplitude(OmegaDalitz());
+    AmpToolsInterface::registerAmplitude(Vec_ps_moment());
 
-  AmpToolsInterface::registerDataReader( ROOTDataReader() );
-  AmpToolsInterface::registerDataReader( FSRootDataReader() );
-  AmpToolsInterface::registerDataReader( ROOTDataReaderTEM() );
+    AmpToolsInterface::registerDataReader(ROOTDataReader());
+    AmpToolsInterface::registerDataReader(FSRootDataReader());
+    AmpToolsInterface::registerDataReader(ROOTDataReaderTEM());
 }
 
 using namespace std;
 
-int main( int argc, char* argv[] ){
-
-
+int main(int argc, char* argv[]) {
     // ************************
     // usage
     // ************************
 
-  cout << endl << " *** Viewing Results Using AmpPlotter and writing root histograms *** " << endl << endl;
+    cout << endl
+         << " *** Viewing Results Using AmpPlotter and writing root histograms "
+            "*** "
+         << endl
+         << endl;
 
-  if (argc < 2){
-    cout << "Usage:" << endl << endl;
-    cout << "\tvecps_plotter <results file name> -o <output file name>" << endl << endl;
-    return 0;
-  }
-
-  bool showGui = false;
-  string outName = "vecps_plot.root";
-  string resultsName(argv[1]);
-  for (int i = 2; i < argc; i++){
-
-    string arg(argv[i]);
-
-    if (arg == "-g"){
-      showGui = true;
+    if (argc < 2) {
+        cout << "Usage:" << endl << endl;
+        cout << "\tvecps_plotter <results file name> -o <output file name>"
+             << endl
+             << endl;
+        return 0;
     }
-    if (arg == "-o"){
-      outName = argv[++i];
-    }
-    if (arg == "-h"){
-      cout << endl << " Usage for: " << argv[0] << endl << endl;
-      cout << "\t -o <file>\t output file path" << endl;
-      cout << "\t -g <file>\t show GUI" << endl;
-      exit(1);
-    }
-  }
 
+    bool showGui = false;
+    string outName = "vecps_plot.root";
+    string resultsName(argv[1]);
+    for (int i = 2; i < argc; i++) {
+        string arg(argv[i]);
+
+        if (arg == "-g") {
+            showGui = true;
+        }
+        if (arg == "-o") {
+            outName = argv[++i];
+        }
+        if (arg == "-h") {
+            cout << endl << " Usage for: " << argv[0] << endl << endl;
+            cout << "\t -o <file>\t output file path" << endl;
+            cout << "\t -g <file>\t show GUI" << endl;
+            exit(1);
+        }
+    }
 
     // ************************
     // parse the command line parameters
     // ************************
 
-  cout << "Fit results file name    = " << resultsName << endl;
-  cout << "Output file name    = " << outName << endl << endl;
+    cout << "Fit results file name    = " << resultsName << endl;
+    cout << "Output file name    = " << outName << endl << endl;
 
     // ************************
     // load the results and display the configuration info
     // ************************
+    cout << "Initializing AmpTools interface..." << endl;
+    atiSetup();
+    cout << "Interface initialized." << endl;
 
-  cout << "Loading Fit results" << endl;
-  FitResults results( resultsName );
-  if( !results.valid() ){
-    
-    cout << "Invalid fit results in file:  " << resultsName << endl;
-    exit( 1 );
-  }
-   cout << "Fit results loaded" << endl;
+    cout << "Loading Fit results" << endl;
+    FitResults results(resultsName);
+    if (!results.valid()) {
+        cout << "Invalid fit results in file:  " << resultsName << endl;
+        exit(1);
+    }
+    cout << "Fit results loaded" << endl;
     // ************************
     // set up the plot generator
     // ************************
-	cout << "before atisetup();"<< endl;
-  atiSetup();
-        cout << "Plotgen results"<< endl;
-
-  vecps_PlotGen plotGen( results , PlotGenerator::kNoGenMC );
-  cout << " Initialized ati and PlotGen" << endl;
+    cout << "Plotgen results" << endl;
+    vecps_PlotGen plotGen(results, PlotGenerator::kNoGenMC);
+    cout << " Initialized ati and PlotGen" << endl;
 
     // ************************
     // set up an output ROOT file to store histograms
     // ************************
+    // Loop over different polarization files assuming 4 polarizations
+    // the default will remain to just use a single file
+    // ************************
+    for (int polFile = 0; polFile < 4; polFile++) {
+        if (polFile > 0) break;  // TEMPORARY - REMOVE TO ENABLE 4 POL FILES
+        string reactionName = results.reactionList()[polFile];
+        outName = reactionName + ".root";
 
-  TFile* plotfile = new TFile( outName.c_str(), "recreate");
-  TH1::AddDirectory(kFALSE);
+        TFile* plotfile = new TFile(outName.c_str(), "recreate");
+        TH1::AddDirectory(kFALSE);
 
-  string reactionName = results.reactionList()[0];
-  plotGen.enableReaction( reactionName );
-  vector<string> sums = plotGen.uniqueSums();
-  vector<string> amps = plotGen.uniqueAmplitudes();
-  cout << "Reaction " << reactionName << " enabled with " << sums.size() << " sums and " << amps.size() << " amplitudes" << endl;
+        plotGen.enableReaction(reactionName);
+        vector<string> sums = plotGen.uniqueSums();
+        vector<string> amps = plotGen.uniqueAmplitudes();
+        cout << "Reaction " << reactionName << " enabled with " << sums.size()
+             << " sums and " << amps.size() << " amplitudes" << endl;
 
-  vector<string> amphistname = {"1pps", "1p0s", "1pms", "1ppd", "1p0d", "1pmd", "1mpp", "1m0p", "1mmp", "1p", "1m"};
-  vector<string> reflname = {"PosRefl", "NegRefl"};
+        const vector<string> amphistname = {"1S-1", "1S+0", "1S+1", "1S",
+                                            "1P-1", "1P+0", "1P+1", "1P",
+                                            "1D-1", "1D+0", "1D+1", "1D"};
+        const vector<string> reflname = {"PosRefl", "NegRefl"};
 
-  // loop over sum configurations (one for each of the individual contributions, and the combined sum of all)
-  for (unsigned int irefl = 0; irefl <= reflname.size(); irefl++){
+        // loop over sum configurations (one for each of the individual
+        // contributions, and the combined sum of all)
+        for (unsigned int irefl = 0; irefl < reflname.size(); irefl++) {
+            // loop over desired amplitudes
+            for (unsigned int iamp = 0; iamp < amphistname.size(); iamp++) {
+                // turn all ampltiudes by default
+                for (unsigned int jamp = 0; jamp < amps.size(); jamp++) {
+                    plotGen.enableAmp(jamp);
+                }
 
-    // loop over desired amplitudes 
-    for (unsigned int iamp = 0; iamp <= amphistname.size(); iamp++ ) {
+                // turn off unwanted amplitudes and sums
+                if (iamp < amphistname.size()) {
+                    string locampname = amphistname[iamp];
 
-      // turn all ampltiudes by default 
-      for (unsigned int jamp = 0; jamp < amps.size(); jamp++ ) {
-	plotGen.enableAmp( jamp );
-      }
+                    // turn on all sums by default
+                    for (unsigned int i = 0; i < sums.size(); i++)
+                        plotGen.enableSum(i);
 
-      // turn off unwanted amplitudes and sums
-      if (iamp < amphistname.size()) {
-	
-        string locampname = amphistname[iamp];
-	
-	// turn on all sums by default
-	for (unsigned int i = 0; i < sums.size(); i++) plotGen.enableSum(i);
+                    // turn off unwanted sums for reflectivity (based on
+                    // naturality) cout<<"refl = "<<irefl<<endl;
+                    if (irefl < 2) {
+                        for (unsigned int i = 0; i < sums.size(); i++) {
+                            if (reflname[irefl] == "NegRefl") {
+                                // ImagNegSign & RealPosSign are defined to be
+                                // the negative reflectivity. So, we turn off
+                                // the positive reflectivity and any sums that
+                                // do not have a sign associated with them like
+                                // an isotropic background
+                                if (sums[i].find("RealNegSign") !=
+                                        std::string::npos ||
+                                    sums[i].find("ImagPosSign") !=
+                                        std::string::npos ||
+                                    sums[i].find("Sign") == std::string::npos) {
+                                    plotGen.disableSum(i);
+                                    // cout<<"disable sum "<<sums[i]<<"\n";
+                                }
+                            }
+                            if (reflname[irefl] == "PosRefl") {
+                                // And, we turn off the negative reflectivity
+                                // and any sums that do not have a sign
+                                // associated with them like an isotropic
+                                // background
+                                if (sums[i].find("ImagNegSign") !=
+                                        std::string::npos ||
+                                    sums[i].find("RealPosSign") !=
+                                        std::string::npos ||
+                                    sums[i].find("Sign") == std::string::npos) {
+                                    // cout<<"disable sum "<<sums[i]<<"\n";
+                                    plotGen.disableSum(i);
+                                }
+                            }
+                        }
+                    }
 
-	// turn off unwanted sums for reflectivity (based on naturality)
-	//cout<<"refl = "<<irefl<<endl;
-	if (irefl < 2) {
-	  for (unsigned int i = 0; i < sums.size(); i++){
-	    if( reflname[irefl] == "NegRefl" ){
-	      //ImagNegSign & RealPosSign are defined to be the negative reflectivity
-	      //So, we turn off the positive reflectivity here
-	      if(sums[i].find("RealNegSign") != std::string::npos || sums[i].find("ImagPosSign") != std::string::npos){
-		plotGen.disableSum(i);
-		//cout<<"disable sum "<<sums[i]<<"\n";
-	      }
-	    }
-	    if( reflname[irefl] == "PosRefl" ){
-	      //And, we turn off the negative reflectivity here
-	      if(sums[i].find("ImagNegSign") != std::string::npos || sums[i].find("RealPosSign") != std::string::npos) {
-		//cout<<"disable sum "<<sums[i]<<"\n";
-		plotGen.disableSum(i);
-	      }
-	    }
-	  }	 
-	}
+                    // turn off unwanted amplitudes
+                    for (unsigned int jamp = 0; jamp < amps.size(); jamp++) {
+                        if (amps[jamp].find(locampname.data()) ==
+                            std::string::npos) {
+                            plotGen.disableAmp(jamp);
+                            // cout<<"disable amplitude "<<amps[jamp]<<endl;
+                        }
+                    }
+                }
 
-	// turn off unwanted amplitudes
-        for (unsigned int jamp = 0; jamp < amps.size(); jamp++ ) {
+                cout << "Looping over input data" << endl;
+                // loop over data, accMC, and genMC
+                for (unsigned int iplot = 0; iplot < PlotGenerator::kNumTypes;
+                     iplot++) {
+                    if (iplot == PlotGenerator::kGenMC ||
+                        iplot == PlotGenerator::kBkgnd)
+                        continue;
+                    bool singleData =
+                        irefl == reflname.size() && iamp == amphistname.size();
+                    if (iplot == PlotGenerator::kData && !singleData)
+                        continue;  // only plot data once
 
-	  if( amps[jamp].find(locampname.data()) == std::string::npos ) {
-	    plotGen.disableAmp( jamp );
-	    //cout<<"disable amplitude "<<amps[jamp]<<endl;
-	  }
-	}
+                    // loop over different variables
+                    for (unsigned int ivar = 0;
+                         ivar < VecPsPlotGenerator::kNumHists; ivar++) {
+                        // set unique histogram name for each plot (could put in
+                        // directories...)
+                        string histname = "";
+                        if (ivar == VecPsPlotGenerator::kVecPsMass)
+                            histname += "MVecPs";
+                        else if (ivar == VecPsPlotGenerator::kCosTheta)
+                            histname += "CosTheta";
+                        else if (ivar == VecPsPlotGenerator::kPhi)
+                            histname += "Phi";
+                        else if (ivar == VecPsPlotGenerator::kCosThetaH)
+                            histname += "CosTheta_H";
+                        else if (ivar == VecPsPlotGenerator::kPhiH)
+                            histname += "Phi_H";
+                        else if (ivar == VecPsPlotGenerator::kProd_Ang)
+                            histname += "Prod_Ang";
+                        else if (ivar == VecPsPlotGenerator::kt)
+                            histname += "t";
+                        else if (ivar == VecPsPlotGenerator::kRecoilMass)
+                            histname += "MRecoil";
+                        else if (ivar == VecPsPlotGenerator::kProtonPsMass)
+                            histname += "MProtonPs";
+                        else if (ivar == VecPsPlotGenerator::kRecoilPsMass)
+                            histname += "MRecoilPs";
+                        else if (ivar == VecPsPlotGenerator::kLambda)
+                            histname += "Lambda";
+                        else if (ivar == VecPsPlotGenerator::kDalitz)
+                            histname += "Dalitz";
+                        else if (ivar == VecPsPlotGenerator::kPhi_ProdVsPhi)
+                            histname += "Phi_ProdVsPhi";
+                        else if (ivar == VecPsPlotGenerator::kPhiOffsetVsPhi)
+                            histname += "PhiOffsetVsPhi";
+                        else
+                            continue;
 
-      }
+                        if (iplot == PlotGenerator::kData) histname += "dat";
+                        if (iplot == PlotGenerator::kBkgnd) histname += "bkgnd";
+                        if (iplot == PlotGenerator::kAccMC) histname += "acc";
+                        if (iplot == PlotGenerator::kGenMC) histname += "gen";
 
-      cout << "Looping over input data" << endl;
-      // loop over data, accMC, and genMC
-      for (unsigned int iplot = 0; iplot < PlotGenerator::kNumTypes; iplot++){
-	if (iplot == PlotGenerator::kGenMC || iplot == PlotGenerator::kBkgnd) continue;
-	bool singleData =  irefl == reflname.size() && iamp == amphistname.size();
-	if ( iplot == PlotGenerator::kData && !singleData ) continue; // only plot data once
-	
-	// loop over different variables
-	for (unsigned int ivar  = 0; ivar  < VecPsPlotGenerator::kNumHists; ivar++){
-	  
-	  // set unique histogram name for each plot (could put in directories...)
-	  string histname =  "";
-	  if (ivar == VecPsPlotGenerator::kVecPsMass)  histname += "MVecPs";
-	  else if (ivar == VecPsPlotGenerator::kCosTheta)  histname += "CosTheta";
-	  else if (ivar == VecPsPlotGenerator::kPhi)  histname += "Phi";
-	  else if (ivar == VecPsPlotGenerator::kCosThetaH)  histname += "CosTheta_H";
-	  else if (ivar == VecPsPlotGenerator::kPhiH)  histname += "Phi_H";
-	  else if (ivar == VecPsPlotGenerator::kProd_Ang)  histname += "Prod_Ang";
-	  else if (ivar == VecPsPlotGenerator::kt)  histname += "t";
-	  else if (ivar == VecPsPlotGenerator::kRecoilMass)  histname += "MRecoil";
-	  else if (ivar == VecPsPlotGenerator::kProtonPsMass)  histname += "MProtonPs";
-	  else if (ivar == VecPsPlotGenerator::kRecoilPsMass)  histname += "MRecoilPs";
-	  else if (ivar == VecPsPlotGenerator::kLambda)  histname += "Lambda";
-	  else if (ivar == VecPsPlotGenerator::kDalitz)  histname += "Dalitz";
-	  else continue;	  
+                        if (irefl < reflname.size()) {
+                            // get name of sum for naming histogram
+                            string sumName = reflname[irefl];
+                            histname += "_";
+                            histname += sumName;
+                        }
+                        if (iamp < amphistname.size()) {
+                            // get name of amp for naming histogram
+                            histname += "_";
+                            histname += amphistname[iamp];
+                        }
 
-	  if (iplot == PlotGenerator::kData) histname += "dat";
-	  if (iplot == PlotGenerator::kBkgnd) histname += "bkgnd";
-	  if (iplot == PlotGenerator::kAccMC) histname += "acc";
-	  if (iplot == PlotGenerator::kGenMC) histname += "gen";
-	  
-	  if (irefl < reflname.size()){
-	    // get name of sum for naming histogram
-	    string sumName = reflname[irefl];
-	    histname += "_";
-	    histname += sumName;
-	  }
-	  if (iamp < amphistname.size()) {
-	    // get name of amp for naming histogram  
-	    histname += "_";
-	    histname += amphistname[iamp];
-	  }
-	  
-	  Histogram* hist = plotGen.projection(ivar, reactionName, iplot);
-	  TH1* thist = hist->toRoot();
-	  thist->SetName(histname.c_str());
-	  plotfile->cd();
-	  thist->Write();
-	  
-	}
-      }
+                        Histogram* hist =
+                            plotGen.projection(ivar, reactionName, iplot);
+                        TH1* thist = hist->toRoot();
+                        thist->SetName(histname.c_str());
+                        plotfile->cd();
+                        thist->Write();
+                    }
+                }
+            }
+        }
+
+        plotfile->Close();
+
+        // The next calculations only need to happen for the first file
+        // and we do not need to repeat for each polarization
+        if (polFile > 0) continue;
+                
+        // model parameters
+        cout << "Checking Parameters" << endl;
+
+        // parameters to check
+        vector<string> pars;
+
+        pars.push_back("dsratio");
+
+        // file for writing parameters (later switch to putting in ROOT file)
+        ofstream outfile;
+        outfile.open("vecps_fitPars.txt");
+
+        for (unsigned int i = 0; i < pars.size(); i++) {
+            double parValue = results.parValue(pars[i]);
+            double parError = results.parError(pars[i]);
+            outfile << parValue << "\t" << parError << "\t" << endl;
+        }
+
+        outfile << "TOTAL EVENTS = " << results.intensity().first << " +- "
+                << results.intensity().second << endl;
+        vector<string> fullamps = plotGen.fullAmplitudes();
+        for (unsigned int i = 0; i < fullamps.size(); i++) {
+            vector<string> useamp;
+            useamp.push_back(fullamps[i]);
+            outfile << "FIT FRACTION " << fullamps[i] << " = "
+                    << results.intensity(useamp).first /
+                           results.intensity().first
+                    << " +- "
+                    << results.intensity(useamp).second /
+                           results.intensity().first
+                    << endl;
+        }
+
+        const int nAmps = amphistname.size();
+        vector<string> ampsumPosRefl[nAmps];
+        vector<string> ampsumNegRefl[nAmps];
+        vector<pair<string, string> > phaseDiffNames;
+
+        for (unsigned int i = 0; i < fullamps.size(); i++) {
+            // combine amplitudes with names defined above
+            for (int iamp = 0; iamp < nAmps; iamp++) {
+                string locampname = amphistname[iamp];
+
+                if (fullamps[i].find("::" + locampname) == std::string::npos)
+                    continue;
+                // cout<<locampname.data()<<" "<<fullamps[i].data()<<endl;
+                // ignore amps without a "sign" as they might not interfere
+                if (fullamps[i].find("Sign") == std::string::npos) continue;
+                // select reflectivity
+                if (fullamps[i].find("ImagNegSign") != std::string::npos ||
+                    fullamps[i].find("RealPosSign") != std::string::npos) {
+                    ampsumNegRefl[iamp].push_back(fullamps[i]);
+                } else {
+                    ampsumPosRefl[iamp].push_back(fullamps[i]);
+                }
+            }
+
+            // second loop over amplitudes to get phase difference names
+            for (unsigned int j = i + 1; j < fullamps.size(); j++) {
+                // only keep amplitudes from the same coherent sum (and ignore
+                // constrained Real)
+                if (fullamps[i].find("Real") != std::string::npos) continue;
+                // ignore amps without a "sign" as they might not interfere
+                if (fullamps[i].find("Sign") == std::string::npos) continue;
+                if (fullamps[i].find("ImagNegSign") != std::string::npos &&
+                    fullamps[j].find("ImagNegSign") == std::string::npos)
+                    continue;
+                if (fullamps[i].find("ImagPosSign") != std::string::npos &&
+                    fullamps[j].find("ImagPosSign") == std::string::npos)
+                    continue;
+
+                phaseDiffNames.push_back(
+                    std::make_pair(fullamps[i], fullamps[j]));
+            }
+        }
+
+        for (int i = 0; i < nAmps; i++) {
+            if (ampsumPosRefl[i].empty()) continue;
+            outfile << "FIT FRACTION (coherent sum) PosRefl " << amphistname[i]
+                    << " = "
+                    << results.intensity(ampsumPosRefl[i]).first /
+                           results.intensity().first
+                    << " +- "
+                    << results.intensity(ampsumPosRefl[i]).second /
+                           results.intensity().first
+                    << endl;
+            outfile << "FIT FRACTION (coherent sum) NegRefl " << amphistname[i]
+                    << " = "
+                    << results.intensity(ampsumNegRefl[i]).first /
+                           results.intensity().first
+                    << " +- "
+                    << results.intensity(ampsumNegRefl[i]).second /
+                           results.intensity().first
+                    << endl;
+        }
+
+        cout << "Computing phase differences" << endl;
+        for (unsigned int i = 0; i < phaseDiffNames.size(); i++) {
+            pair<double, double> phaseDiff = results.phaseDiff(
+                phaseDiffNames[i].first, phaseDiffNames[i].second);
+            outfile << "PHASE DIFF " << phaseDiffNames[i].first << " "
+                    << phaseDiffNames[i].second << " " << phaseDiff.first << " "
+                    << phaseDiff.second << endl;
+        }
     }
-  }
 
-  plotfile->Close();
-
-  // model parameters
-  cout << "Checking Parameters" << endl;
-  
-  // parameters to check
-  vector< string > pars;
-  
-  pars.push_back("dsratio");
-
-  // file for writing parameters (later switch to putting in ROOT file)
-  ofstream outfile;
-  outfile.open( "vecps_fitPars.txt" );
-
-  for(unsigned int i = 0; i<pars.size(); i++) {
-    double parValue = results.parValue( pars[i] );
-    double parError = results.parError( pars[i] );
-    outfile << parValue << "\t" << parError << "\t" << endl;
-  }
-
-  outfile << "TOTAL EVENTS = " << results.intensity().first << " +- " << results.intensity().second << endl;
-  vector<string> fullamps = plotGen.fullAmplitudes();
-  for (unsigned int i = 0; i < fullamps.size(); i++){
-    vector<string> useamp;  useamp.push_back(fullamps[i]);
-    outfile << "FIT FRACTION " << fullamps[i] << " = "
-         << results.intensity(useamp).first /
-            results.intensity().first <<  " +- "
-         << results.intensity(useamp).second /
-            results.intensity().first <<  endl;
-  }
-
-  const int nAmps = amphistname.size();
-  vector<string> ampsumPosRefl[nAmps];
-  vector<string> ampsumNegRefl[nAmps];
-  vector< pair<string,string> > phaseDiffNames;
-  
-  for(unsigned int i = 0; i < fullamps.size(); i++){
-
-    // combine amplitudes with names defined above
-    for(int iamp=0; iamp<nAmps; iamp++) {
-	    string locampname = amphistname[iamp];
-	    
-	    if(fullamps[i].find("::" + locampname) == std::string::npos) continue;
-	    //cout<<locampname.data()<<" "<<fullamps[i].data()<<endl;
-
-	    // select reflectivity
-	    if(fullamps[i].find("ImagNegSign") != std::string::npos || fullamps[i].find("RealPosSign") != std::string::npos) {
-	      ampsumNegRefl[iamp].push_back(fullamps[i]);
-	    }
-	    else {
-	      ampsumPosRefl[iamp].push_back(fullamps[i]);
-	    }
-    }
-
-    // second loop over amplitudes to get phase difference names
-    for(unsigned int j = i+1; j < fullamps.size(); j++){
-
-      // only keep amplitudes from the same coherent sum (and ignore constrained Real)
-      if(fullamps[i].find("Real") != std::string::npos) continue;
-      if(fullamps[i].find("ImagNegSign") != std::string::npos && fullamps[j].find("ImagNegSign") == std::string::npos) continue;
-      if(fullamps[i].find("ImagPosSign") != std::string::npos && fullamps[j].find("ImagPosSign") == std::string::npos) continue;
-	    
-      phaseDiffNames.push_back( std::make_pair(fullamps[i], fullamps[j]) );
-
-    }
-  }
-
-  for(int i = 0; i < nAmps; i++){
-    if(ampsumPosRefl[i].empty()) continue;
-    outfile << "FIT FRACTION (coherent sum) PosRefl " << amphistname[i] << " = "
-          << results.intensity(ampsumPosRefl[i]).first / results.intensity().first << " +- "
-          << results.intensity(ampsumPosRefl[i]).second / results.intensity().first << endl;
-     outfile << "FIT FRACTION (coherent sum) NegRefl " << amphistname[i] << " = "
-          << results.intensity(ampsumNegRefl[i]).first / results.intensity().first << " +- "
-          << results.intensity(ampsumNegRefl[i]).second / results.intensity().first << endl;
-  }
-
-cout<<"Computing phase differences"<<endl;
-  for(unsigned int i = 0; i < phaseDiffNames.size(); i++) {
-	  pair <double, double> phaseDiff = results.phaseDiff( phaseDiffNames[i].first, phaseDiffNames[i].second );
-	  outfile << "PHASE DIFF " << phaseDiffNames[i].first << " " << phaseDiffNames[i].second << " " << phaseDiff.first << " " << phaseDiff.second << endl;
-
-  }
-
-  // covariance matrix
-  vector< vector< double > > covMatrix;
-  covMatrix = results.errorMatrix();
+    // covariance matrix
+    vector<vector<double> > covMatrix;
+    covMatrix = results.errorMatrix();
 
     // ************************
     // start the GUI
     // ************************
 
-  if(showGui) {
+    if (showGui) {
+        cout << ">> Plot generator ready, starting GUI..." << endl;
 
-	  cout << ">> Plot generator ready, starting GUI..." << endl;
-	  
-	  int dummy_argc = 0;
-	  char* dummy_argv[] = {};  
-	  TApplication app( "app", &dummy_argc, dummy_argv );
-	  
-	  gStyle->SetFillColor(10);
-	  gStyle->SetCanvasColor(10);
-	  gStyle->SetPadColor(10);
-	  gStyle->SetFillStyle(1001);
-	  gStyle->SetPalette(1);
-	  gStyle->SetFrameFillColor(10);
-	  gStyle->SetFrameFillStyle(1001);
-   
-     cout << " Initialized App " << endl;     
-	  PlotFactory factory( plotGen );	
-     cout << " Created Plot Factory " << endl;
-	  PlotterMainWindow mainFrame( gClient->GetRoot(), factory );
-     cout << " Main frame created " << endl;
-	  
-	  app.Run();
-     cout << " App running" << endl;
-  }
-    
-  return 0;
+        int dummy_argc = 0;
+        char* dummy_argv[] = {};
+        TApplication app("app", &dummy_argc, dummy_argv);
 
+        gStyle->SetFillColor(10);
+        gStyle->SetCanvasColor(10);
+        gStyle->SetPadColor(10);
+        gStyle->SetFillStyle(1001);
+        gStyle->SetPalette(1);
+        gStyle->SetFrameFillColor(10);
+        gStyle->SetFrameFillStyle(1001);
+
+        cout << " Initialized App " << endl;
+        PlotFactory factory(plotGen);
+        cout << " Created Plot Factory " << endl;
+        PlotterMainWindow mainFrame(gClient->GetRoot(), factory);
+        cout << " Main frame created " << endl;
+
+        app.Run();
+        cout << " App running" << endl;
+    }
+
+    return 0;
 }

--- a/src/programs/AmplitudeAnalysis/vecps_plotter/vecps_plotter.cc
+++ b/src/programs/AmplitudeAnalysis/vecps_plotter/vecps_plotter.cc
@@ -122,11 +122,12 @@ int main(int argc, char* argv[]) {
     // ************************
     // set up an output ROOT file to store histograms
     // ************************
-    // Loop over different polarization files assuming 4 polarizations
+    // Loop over different polarization files 
     // the default will remain to just use a single file
     // ************************
-    for (int polFile = 0; polFile < 4; polFile++) {
-        if (polFile > 0) break;  // TEMPORARY - REMOVE TO ENABLE 4 POL FILES
+    size_t nReactions = results.reactionList().size();
+    for (int polFile = 0; polFile < nReactions; polFile++) {
+        if (polFile > 0) break;  // TEMPORARY - REMOVE TO ENABLE ALL POL FILES
         string reactionName = results.reactionList()[polFile];
         outName = reactionName + ".root";
 
@@ -146,9 +147,9 @@ int main(int argc, char* argv[]) {
 
         // loop over sum configurations (one for each of the individual
         // contributions, and the combined sum of all)
-        for (unsigned int irefl = 0; irefl < reflname.size(); irefl++) {
+        for (unsigned int irefl = 0; irefl <= reflname.size(); irefl++) {
             // loop over desired amplitudes
-            for (unsigned int iamp = 0; iamp < amphistname.size(); iamp++) {
+            for (unsigned int iamp = 0; iamp <= amphistname.size(); iamp++) {
                 // turn all ampltiudes by default
                 for (unsigned int jamp = 0; jamp < amps.size(); jamp++) {
                     plotGen.enableAmp(jamp);

--- a/src/programs/Simulation/gen_omegapi/gen_omegapi.cc
+++ b/src/programs/Simulation/gen_omegapi/gen_omegapi.cc
@@ -19,7 +19,7 @@
 #include "AMPTOOLS_DATAIO/ASCIIDataWriter.h"
 
 #include "AMPTOOLS_AMPS/omegapi_amplitude.h"
-#include "AMPTOOLS_AMPS/omegapiAngles.h"
+#include "AMPTOOLS_AMPS/vecPsAngles.h"
 #include "AMPTOOLS_AMPS/Vec_ps_refl.h"
 #include "AMPTOOLS_AMPS/BreitWigner.h"
 #include "AMPTOOLS_AMPS/Uniform.h"

--- a/src/programs/Simulation/gen_omegapi/gen_omegapi.cc
+++ b/src/programs/Simulation/gen_omegapi/gen_omegapi.cc
@@ -553,33 +553,33 @@ int main( int argc, char* argv[] ){
 					
 					t->Fill(-1*(recoil-target).M2());
 
-                                        TLorentzVector Gammap = beam + target;
-                                        vector <double> loccosthetaphi = getomegapiAngles(polAngle, isobar, resonance, beam, Gammap);
-                                        double cosTheta = cos(loccosthetaphi[0]);
-                                        double phi = loccosthetaphi[1];
+                    TLorentzVector Gammap = beam + target;
+                    vector <double> xDecayAngles = getXDecayAngles(polAngle, beam, Gammap, isobar, resonance);
+                    double cosTheta = cos(xDecayAngles[0]);
+                    double phi = xDecayAngles[1];
+					double Phi = xDecayAngles[2];
 
-                                        vector <double> loccosthetaphih = getomegapiAngles( p3, isobar, resonance, Gammap, p4);
-                                        double cosThetaH = cos(loccosthetaphih[0]);
-                                        double phiH = loccosthetaphih[1];
+                    vector <double> vectorDecayAngles = getVectorDecayAngles( Gammap, isobar, resonance, p3, p4);
+                    double cosThetaH = cos(vectorDecayAngles[0]);
+                    double phiH = vectorDecayAngles[1];
+					double lambda_omega = vectorDecayAngles[2];
 
 					M_CosTheta->Fill( resonance.M(), cosTheta);
 					M_Phi->Fill( resonance.M(), phi);
 					M_CosThetaH->Fill( resonance.M(), cosThetaH);
 					M_PhiH->Fill( resonance.M(), phiH);
 
-					double lambda_omega = loccosthetaphih[2];
 					lambda->Fill(lambda_omega);
 
-                                        double Phi = loccosthetaphi[2];
 					M_Phi_Prod->Fill( resonance.M(), Phi);
 
-                                        GDouble psi = phi - Phi;
-                                        if(psi < -1*PI) psi += 2*PI;
-                                        if(psi > PI) psi -= 2*PI;
+                    GDouble psi = phi - Phi;
+                    if(psi < -1*PI) psi += 2*PI;
+                    if(psi > PI) psi -= 2*PI;
 
 					GDouble psiprime = phi + Phi;
-                                        if(psiprime < -1*PI) psiprime += 2*PI;
-                                        if(psiprime > PI) psiprime -= 2*PI;
+                    if(psiprime < -1*PI) psiprime += 2*PI;
+                    if(psiprime > PI) psiprime -= 2*PI;
 					
 					CosTheta_psi->Fill( psi, cosTheta);
 					PhiH_Psi->Fill(psi, phiH);

--- a/src/programs/Simulation/gen_vec_ps/gen_vec_ps.cc
+++ b/src/programs/Simulation/gen_vec_ps/gen_vec_ps.cc
@@ -18,7 +18,7 @@
 #include "AMPTOOLS_MCGEN/HDDMDataWriter.h"
 #include "AMPTOOLS_DATAIO/ASCIIDataWriter.h"
 
-#include "AMPTOOLS_AMPS/omegapiAngles.h"
+#include "AMPTOOLS_AMPS/vecPsAngles.h"
 #include "AMPTOOLS_AMPS/Vec_ps_refl.h"
 #include "AMPTOOLS_AMPS/Vec_ps_moment.h"
 #include "AMPTOOLS_AMPS/BreitWigner.h"

--- a/src/programs/Simulation/gen_vec_ps/gen_vec_ps.cc
+++ b/src/programs/Simulation/gen_vec_ps/gen_vec_ps.cc
@@ -565,29 +565,31 @@ int main( int argc, char* argv[] ){
 
 					t->Fill(-1*(recoil-target).M2());
 
-                                        TLorentzVector Gammap = beam + target;
-                                        vector <double> loccosthetaphi = getomegapiAngles(polAngle, isobar, resonance, beam, Gammap);
-                                        double cosTheta = cos(loccosthetaphi[0]);
-                                        double phi = loccosthetaphi[1];
+					TLorentzVector Gammap = beam + target;
+                    vector <double> xDecayAngles = getXDecayAngles(polAngle, beam, Gammap, isobar, resonance);
+                    double cosTheta = cos(xDecayAngles[0]);
+                    double phi = xDecayAngles[1];
+					double Phi = xDecayAngles[2];
 
-                                        vector <double> loccosthetaphih = getomegapiAngles( p3, isobar, resonance, Gammap, p4);
-                                        double cosThetaH = cos(loccosthetaphih[0]);
-                                        double phiH = loccosthetaphih[1];
+                    vector <double> vectorDecayAngles = getVectorDecayAngles( Gammap, isobar, resonance, p3, p4);
+                    double cosThetaH = cos(vectorDecayAngles[0]);
+                    double phiH = vectorDecayAngles[1];
+					double lambda_omega = vectorDecayAngles[2];
 
 					M_CosTheta->Fill( resonance.M(), cosTheta);
 					M_Phi->Fill( resonance.M(), phi);
 					M_CosThetaH->Fill( resonance.M(), cosThetaH);
 					M_PhiH->Fill( resonance.M(), phiH);
 
-					double lambda_omega = loccosthetaphih[2];
+					
 					lambda->Fill(lambda_omega);
 
-                                        double Phi = loccosthetaphi[2];
+                                        
 					M_Phi_Prod->Fill( resonance.M(), Phi);
 
-                                        GDouble psi = phi - Phi;
-                                        if(psi < -1*PI) psi += 2*PI;
-                                        if(psi > PI) psi -= 2*PI;
+                    GDouble psi = phi - Phi;
+                    if(psi < -1*PI) psi += 2*PI;
+                    if(psi > PI) psi -= 2*PI;
 
 					CosTheta_psi->Fill( psi, cosTheta);
 

--- a/src/programs/Simulation/gen_vec_ps/gen_vec_ps.cc
+++ b/src/programs/Simulation/gen_vec_ps/gen_vec_ps.cc
@@ -566,6 +566,10 @@ int main( int argc, char* argv[] ){
 					t->Fill(-1*(recoil-target).M2());
 
 					TLorentzVector Gammap = beam + target;
+					if( polAngle == -1 ){
+						fprintf(stderr, "Error: do not use amorphous value (got %d)\n", polAngle);
+        				return -1; 
+					}
                     vector <double> xDecayAngles = getXDecayAngles(polAngle, beam, Gammap, isobar, resonance);
                     double cosTheta = cos(xDecayAngles[0]);
                     double phi = xDecayAngles[1];


### PR DESCRIPTION
Here are what was updated:
+ omegaPiAngles: 
     - Improved clarity
     - Changed name and order of functions and their inputs
     - Insted of copying the values, the functions now reference them to improve speed
     - A safety check is used to make sure radians (abs(polAngle) < 2pi) are passed in the functions. If they aren't passed, they will be changed. 
+ vec_ps_refl and vecPsPlotGenerator:
     - Safety check to make sure only numbers are passed for the polarization angle
     - Adapted changes from omegaPiAngles
     - Formatting changes
     - The plot generator now has new default histograms to keep track of the production angle
+ omegapi_amplitude and vec_ps_moments:
     - Adapted to omegaPiAngles changes
+ gen_omegapi and gen_vecps:
     - Adapted to omegaPiAngles changes
     - Added a lock to avoid passing the value -1 for pol angle
 + vecps_plotter:
     - Changed loop logic so that it can loop 4 pol files. However, the default is still to run over a single file
     - Adapted to new amplitude convention
     - Added new default histograms