### PR TITLE
add untagged option to BeamProperties

### DIFF
--- a/src/libraries/UTILITIES/BeamProperties.cc
+++ b/src/libraries/UTILITIES/BeamProperties.cc
@@ -465,6 +465,7 @@ void BeamProperties::fillTaggedFluxFromCCDB() {
 	// Setup custom histogram for filling flux from CCDB
 	double Elow  = mBeamParametersMap.at("PhotonBeamLowEnergy"); // histogram min energy
 	double Ehigh = mBeamParametersMap.at("PhotonBeamHighEnergy"); // histogram max energy
+	/*
 	int highest_tagh = 0;
 	vector<double> Elows_tagh;
 	for(int i=tagh_scaled_energy.size()-1; i>=0; i--) {
@@ -487,6 +488,7 @@ void BeamProperties::fillTaggedFluxFromCCDB() {
 	}
 	Elows_tagm.push_back(tagm_scaled_energy[highest_tagm][2] * photon_endpoint[0]);	// add high energy edge for last counter
 	sort(Elows_tagm.begin(), Elows_tagm.end());
+	*/
 	fluxVsEgamma = new TH1D("BeamProperties_FluxVsEgamma", "Flux vs. E_{#gamma}", (int) ((Ehigh - Elow) * 1e6), Elow, Ehigh);
 
 	// Get tagged flux from CCDB and fill histogram (if they exist)
@@ -509,11 +511,12 @@ void BeamProperties::fillTaggedFluxFromCCDB() {
 	for(uint i=0; i<taghflux.size(); i++) {
 	  e_low = tagh_scaled_energy[i][1] * endpoint_calib[0] + delta_e;
 	  e_high = tagh_scaled_energy[i][2] * endpoint_calib[0] + delta_e;
+	  int nbin = (int) ((e_high - e_low) * 1e6);
 	  //double energy = 0.5*(tagh_scaled_energy[i][1]+tagh_scaled_energy[i][2]) * photon_endpoint[0];
 	  for (int e = ((int) (e_low * 1e6)); e <= ((int) (e_high * 1e6)); e ++) {
 	    double energy = e * 1e-6;
 	    double accept = PSAcceptance(energy, PSnorm, PSmin, PSmax);
-	    double flux = taghflux[i][1]/accept;
+	    double flux = taghflux[i][1]/accept/((double) nbin);
 	    if(accept < 0.01) flux = 0; // remove very low acceptance regions to avoid fluctuations
 	    if(e_low_tagm <= energy && energy <= e_high_tagm) flux = 0; // remove very low acceptance regions to avoid fluctuations
 	    fluxVsEgamma->Fill(energy, flux);
@@ -523,11 +526,12 @@ void BeamProperties::fillTaggedFluxFromCCDB() {
 	for(uint i=0; i<tagmflux.size(); i++) {
 	  e_low = tagm_scaled_energy[i][1] * endpoint_calib[0] + delta_e;
 	  e_high = tagm_scaled_energy[i][2] * endpoint_calib[0] + delta_e;
+	  int nbin = (int) ((e_high - e_low) * 1e6);
 	  //double energy = 0.5*(tagm_scaled_energy[i][1]+tagm_scaled_energy[i][2]) * photon_endpoint[0];
 	  for (int e = ((int) (e_low * 1e6)); e <= ((int) (e_high * 1e6)); e ++) {
 	    double energy = e * 1e-6;
 	    double accept = PSAcceptance(energy, PSnorm, PSmin, PSmax);
-	    double flux = tagmflux[i][1]/accept;
+	    double flux = tagmflux[i][1]/accept/((double) nbin);
 	    if(accept < 0.01) flux = 0; // remove very low acceptance regions to avoid fluctuations
 	    fluxVsEgamma->Fill(energy, flux);
 	  }

--- a/src/libraries/UTILITIES/BeamProperties.cc
+++ b/src/libraries/UTILITIES/BeamProperties.cc
@@ -117,9 +117,10 @@ bool BeamProperties::parseConfig(){
 		else if(words[0].find("ROOTFlux") != std::string::npos) {
 			if(words[1] == "ccdb")
 				mIsCCDBFlux = true;
-			else if (words[1] == "tagged-ccdb")
+			else if (words[1] == "tagged-ccdb") {
 			        mIsCCDBTaggedFlux = true;
-			else {
+				cout << "tagged-ccdb" << endl;
+			} else {
 				mIsROOTFlux = true;
 				mBeamHistNameMap.insert( std::pair<std::string,std::string>( words[0].data(), words[1].data() ) );
 			}
@@ -316,7 +317,7 @@ double BeamProperties::PSAcceptance(double Egamma, double norm, double min, doub
 // create histograms for flux from CCDB for specified run number  and polarization fraction
 void BeamProperties::fillFluxFromCCDB() {
 
-	cout<<endl<<"BeamProperties: Using flux from CCDB run "<<mRunNumber<<endl;
+	cout<<endl<<"BeamProperties: Using untagged flux from CCDB run "<<mRunNumber<<endl;
 
 	// Parse environment variables for CCDB setup
 	const char *calib_url = getenv("JANA_CALIB_URL");
@@ -476,7 +477,7 @@ void BeamProperties::fillTaggedFluxFromCCDB() {
 	}
 	Elows_tagm.push_back(tagm_scaled_energy[highest_tagm][2] * photon_endpoint[0]);	// add high energy edge for last counter
 	sort(Elows_tagm.begin(), Elows_tagm.end());
-      	fluxVsEgamma = new TH1D("BeamProperties_FluxVsEgamma", "Flux vs. E_{#gamma}", (int) ((Ehigh - Elow) / 10.), Elow, Ehigh);
+	fluxVsEgamma = new TH1D("BeamProperties_FluxVsEgamma", "Flux vs. E_{#gamma}", (int) ((Ehigh - Elow) * 1e3 / 10.), Elow, Ehigh);
 
 	// Get tagged flux from CCDB and fill histogram (if they exist)
 	try{
@@ -494,7 +495,7 @@ void BeamProperties::fillTaggedFluxFromCCDB() {
 		cout << "ERROR: Failed to find flux table in CCDB for run " << mRunNumber << endl;
 		exit(101);
 	}
-		
+	
 	for(uint i=0; i<taghflux.size(); i++) {
 		double energy = 0.5*(tagh_scaled_energy[i][1]+tagh_scaled_energy[i][2]) * photon_endpoint[0];
 		double accept = PSAcceptance(energy, PSnorm, PSmin, PSmax);

--- a/src/libraries/UTILITIES/BeamProperties.cc
+++ b/src/libraries/UTILITIES/BeamProperties.cc
@@ -40,6 +40,8 @@ void BeamProperties::createHistograms( TString configFile ) {
 	// Fill flux histogram based on config file
 	if(mIsCCDBFlux)
 		fillFluxFromCCDB();
+	else if(mIsCCDBTaggedFlux)
+	  	fillTaggedFluxFromCCDB();
 	else if(mIsROOTFlux)
 		fillFluxFromROOT();
 	else {  // default to CobremsGeneration for flux and polarization
@@ -64,6 +66,7 @@ bool BeamProperties::parseConfig(){
 	cout<<endl<<"BeamProperties: Parsing config file "<<mConfigFile.Data()<<endl;
 
 	// start assuming parameters for CobremsGeneration
+	mIsCCDBTaggedFlux = false;
 	mIsCCDBFlux = false;
 	mIsCCDBPol = false;
 	mIsROOTFlux = false;
@@ -112,8 +115,10 @@ bool BeamProperties::parseConfig(){
 			mBeamParametersMap.insert( std::pair<std::string,double>( words[0].data(), atof(words[1].data()) ));
 		}
 		else if(words[0].find("ROOTFlux") != std::string::npos) {
-			if(words[1].find("ccdb") != std::string::npos)
+			if(words[1] == "ccdb")
 				mIsCCDBFlux = true;
+			else if (words[1] == "tagged-ccdb")
+			        mIsCCDBTaggedFlux = true;
 			else {
 				mIsROOTFlux = true;
 				mBeamHistNameMap.insert( std::pair<std::string,std::string>( words[0].data(), words[1].data() ) );
@@ -353,7 +358,7 @@ void BeamProperties::fillFluxFromCCDB() {
 	int highest_tagh = 0;
 	vector<double> Elows_tagh;
 	for(int i=tagh_scaled_energy.size()-1; i>=0; i--) {
-		double energy = tagh_scaled_energy[i][1] * photon_endpoint[0];
+	        double energy = tagh_scaled_energy[i][1] * photon_endpoint[0];
 		if(energy > Elow && energy < Ehigh) { // keep only untagged flux for requested range
 			Elows_tagh.push_back(energy);
 			highest_tagh = i;
@@ -390,6 +395,131 @@ void BeamProperties::fillFluxFromCCDB() {
 
 	return;
 }
+
+
+
+// create histograms for flux from CCDB for specified run number  and polarization fraction
+void BeamProperties::fillTaggedFluxFromCCDB() {
+
+	cout<<endl<<"BeamProperties: Using tagged flux from CCDB run "<<mRunNumber<<endl;
+
+	// Parse environment variables for CCDB setup
+	const char *calib_url = getenv("JANA_CALIB_URL");
+	if(!calib_url) {
+		cout<<"Can't compute flux with undefined JANA_CALIB_URL environment variable"<<endl;
+		exit(101);
+	}
+
+	string variation = "default";
+	const char *variation_env = getenv("JANA_CALIB_CONTEXT");
+	if(variation_env) { // use non-default context if provided
+		variation = string(variation_env);
+		variation = variation.substr(variation.find('=')+1,variation.find(' ')-variation.find('=')-1); //keep only the actual variation
+		cout<<"Using CCDB variation = "<<variation.data()<<endl;
+	}
+
+	// Generate calibration class
+	unique_ptr<ccdb::Calibration> calib(ccdb::CalibrationGenerator::CreateCalibration(string(calib_url), mRunNumber, variation));
+
+	// Get PS acceptance from CCDB
+	vector< vector<double> > psAccept;
+        calib->GetCalib(psAccept, "/PHOTON_BEAM/pair_spectrometer/lumi/PS_accept");
+
+	// find acceptance function parameters
+	double PSnorm = psAccept[0][0];
+	double PSmin = psAccept[0][1];
+	double PSmax = psAccept[0][2];
+
+	// Get tagger energy parameters from CCDB
+	vector< double > photon_endpoint;
+	vector< vector<double> > tagh_scaled_energy, tagm_scaled_energy;
+	calib->GetCalib(photon_endpoint, "PHOTON_BEAM/endpoint_energy");
+	calib->GetCalib(tagh_scaled_energy, "PHOTON_BEAM/hodoscope/scaled_energy_range");
+	calib->GetCalib(tagm_scaled_energy, "PHOTON_BEAM/microscope/scaled_energy_range");
+
+	double e_low_tagh = 0;
+	double e_high_tagh = 0;
+	double e_low_tagm = 0;
+	double e_high_tagm = 0;
+
+	if (tagh_scaled_energy.size() > 0) {
+	  e_low_tagh = tagh_scaled_energy[tagh_scaled_energy.size() - 1][1] * photon_endpoint[0];
+	  e_high_tagh = tagh_scaled_energy[0][2] * photon_endpoint[0];
+	}
+	if (tagm_scaled_energy.size() > 0) {
+	  e_low_tagm = tagm_scaled_energy[tagm_scaled_energy.size() - 1][1] * photon_endpoint[0];
+	  e_high_tagm = tagm_scaled_energy[0][2] * photon_endpoint[0];
+	}
+	
+	// Setup custom histogram for filling flux from CCDB
+	double Elow  = mBeamParametersMap.at("PhotonBeamLowEnergy"); // histogram min energy
+	double Ehigh = mBeamParametersMap.at("PhotonBeamHighEnergy"); // histogram max energy
+	int highest_tagh = 0;
+	vector<double> Elows_tagh;
+	for(int i=tagh_scaled_energy.size()-1; i>=0; i--) {
+		double energy = tagh_scaled_energy[i][1] * photon_endpoint[0];
+		if(energy > Elow && energy < Ehigh) { // keep only tagged flux for requested range
+			Elows_tagh.push_back(energy);
+			highest_tagh = i;
+		}
+	}
+	Elows_tagh.push_back(tagh_scaled_energy[highest_tagh][2] * photon_endpoint[0]);	// add high energy edge for last counter
+	sort(Elows_tagh.begin(), Elows_tagh.end());
+	int highest_tagm = 0;
+	vector<double> Elows_tagm;
+	for(int i=tagm_scaled_energy.size()-1; i>=0; i--) {
+		double energy = tagm_scaled_energy[i][1] * photon_endpoint[0];
+		if(energy > Elow && energy < Ehigh) { // keep only tagged flux for requested range
+			Elows_tagm.push_back(energy);
+			highest_tagm = i;
+		}
+	}
+	Elows_tagm.push_back(tagm_scaled_energy[highest_tagm][2] * photon_endpoint[0]);	// add high energy edge for last counter
+	sort(Elows_tagm.begin(), Elows_tagm.end());
+      	fluxVsEgamma = new TH1D("BeamProperties_FluxVsEgamma", "Flux vs. E_{#gamma}", (int) ((Ehigh - Elow) / 10.), Elow, Ehigh);
+
+	// Get tagged flux from CCDB and fill histogram (if they exist)
+	try{
+		if(!calib->GetCalib(taghflux, "PHOTON_BEAM/pair_spectrometer/lumi/tagh/tagged")) {
+			cout << "ERROR: Flux not available in CCDB for run " << mRunNumber << endl;
+			exit(101);
+		}
+		if(!calib->GetCalib(tagmflux, "PHOTON_BEAM/pair_spectrometer/lumi/tagm/tagged")) {
+			cout << "ERROR: Flux not available in CCDB for run " << mRunNumber << endl;
+			exit(101);
+		}
+	}
+	
+	catch (std::exception &) {
+		cout << "ERROR: Failed to find flux table in CCDB for run " << mRunNumber << endl;
+		exit(101);
+	}
+		
+	for(uint i=0; i<taghflux.size(); i++) {
+		double energy = 0.5*(tagh_scaled_energy[i][1]+tagh_scaled_energy[i][2]) * photon_endpoint[0];
+		double accept = PSAcceptance(energy, PSnorm, PSmin, PSmax);
+		double flux = taghflux[i][1]/accept;
+		if(accept < 0.01) flux = 0; // remove very low acceptance regions to avoid fluctuations
+		if(e_low_tagm <= energy && energy <= e_high_tagm) flux = 0; // remove very low acceptance regions to avoid fluctuations
+		fluxVsEgamma->Fill(energy, flux);
+	}
+
+	for(uint i=0; i<tagmflux.size(); i++) {
+		double energy = 0.5*(tagm_scaled_energy[i][1]+tagm_scaled_energy[i][2]) * photon_endpoint[0];
+		double accept = PSAcceptance(energy, PSnorm, PSmin, PSmax);
+		double flux = tagmflux[i][1]/accept;
+		if(accept < 0.01) flux = 0; // remove very low acceptance regions to avoid fluctuations
+		fluxVsEgamma->Fill(energy, flux);
+	}
+
+	if (fluxVsEgamma->Integral() == 0){
+	  cout << "ERROR: Flux in CCDB not available for this energy range!" << endl;
+	  exit(101);
+	}
+
+	return;
+}
+
 
 // PLACEHOLDER: create histograms for polarization fraction from CCDB for specified run number
 void BeamProperties::fillPolFromCCDB() {

--- a/src/libraries/UTILITIES/BeamProperties.h
+++ b/src/libraries/UTILITIES/BeamProperties.h
@@ -32,6 +32,7 @@ public:
 
   // flux stored by channel
   flux_t taghflux;
+  flux_t tagmflux;
 	
 private:
 
@@ -41,6 +42,7 @@ private:
   void fillFluxFromROOT();
   void fillPolFromROOT();
   void fillFluxFromCCDB();
+  void fillTaggedFluxFromCCDB();
   void fillPolFromCCDB();
   void fillPolFixed();
   double PSAcceptance(double Egamma, double norm, double min, double max);
@@ -49,6 +51,7 @@ private:
   std::map<std::string,double> mBeamParametersMap;
   std::map<std::string,std::string> mBeamHistNameMap;
 
+  bool mIsCCDBTaggedFlux;
   bool mIsCCDBFlux, mIsCCDBPol;
   bool mIsROOTFlux, mIsROOTPol;
   bool mIsPolFixed;

--- a/src/libraries/UTILITIES/BeamProperties.h
+++ b/src/libraries/UTILITIES/BeamProperties.h
@@ -17,8 +17,8 @@
 
 #include "CCDB/Calibration.h"
 #include "CCDB/CalibrationGenerator.h"
-#include "TRandom3.h"
-#include <TTimeStamp.h>
+//#include "TRandom3.h"
+//#include <TTimeStamp.h>
 
 typedef vector< vector<double> > flux_t;
 

--- a/src/libraries/UTILITIES/BeamProperties.h
+++ b/src/libraries/UTILITIES/BeamProperties.h
@@ -17,6 +17,8 @@
 
 #include "CCDB/Calibration.h"
 #include "CCDB/CalibrationGenerator.h"
+#include "TRandom3.h"
+#include <TTimeStamp.h>
 
 typedef vector< vector<double> > flux_t;
 

--- a/src/programs/Simulation/gen_primex_eta_he4/gen_primex_eta_he4.cc
+++ b/src/programs/Simulation/gen_primex_eta_he4/gen_primex_eta_he4.cc
@@ -271,7 +271,17 @@ int main( int argc, char* argv[] ){
     if (m_meson == "pi0") m_meson = "Pi0";
     if (m_meson == "eta") m_meson = "Eta";
     if (m_meson == "eta'") m_meson = "EtaPrime";
-    if (m_meson == "omega") m_meson = "Omega";
+    if (m_meson == "omega") {
+      m_meson = "Omega";
+      cout << " Omega special " << endl;
+      if (ReadFile->GetConfigName("sc1") != "" && ReadFile->GetConfigName("sc2") != "") {
+	cout << " that decays " << endl;
+	m_sc[0] = ReadFile->GetConfigName("sc1");
+	m_sc[1] = ReadFile->GetConfigName("sc2");
+	if (m_sc[0] == "Gamma") m_sc[0] = "Photon";
+	if (m_sc[1] == "Gamma") m_sc[1] = "Photon";
+      }
+    }
     if (m_meson == "rho0" || m_meson == "Rho0") {
       m_meson = "Rho0";
       cout << " Rho0 special " << endl;
@@ -279,6 +289,8 @@ int main( int argc, char* argv[] ){
 	cout << " that decays " << endl;
 	m_sc[0] = ReadFile->GetConfigName("sc1");
 	m_sc[1] = ReadFile->GetConfigName("sc2");
+	if (m_sc[0] == "Gamma") m_sc[0] = "Photon";
+	if (m_sc[1] == "Gamma") m_sc[1] = "Photon";
       }
     }
     if (m_meson != "Eta" && m_meson != "EtaPrime" && m_meson != "Pi0" && m_meson != "Omega" && m_meson != "Rho0") {
@@ -315,7 +327,7 @@ int main( int argc, char* argv[] ){
   Particle_t t_spectator = Gamma;
   Particle_t t_participant = Gamma;
 
-  if (m_meson == "Rho0") {
+  if (m_meson == "Rho0" || m_meson == "Omega") {
     if (m_sc[0] != "" && m_sc[1] != "") {
       cout << m_meson << " decay into " << m_sc[0] << " and " << m_sc[1] << endl;
       t_sc1 = ParticleEnum(m_sc[0].Data());
@@ -433,7 +445,9 @@ int main( int argc, char* argv[] ){
 
   TH1F * h_meson_mass = new TH1F("meson_mass","; Mass [GeV];Events #", 2000, 0., 2.);
   TH1F * h_meson_theta = new TH1F("meson_theta","; cos;Events #", 2000, -1., 1.);
-  
+  TLorentzVector sc1P4_lab(0, 0, 0, 0);
+  TLorentzVector sc2P4_lab(0, 0, 0, 0);
+    
   for (int i = 0; i < nEvents; ++i) {
     if (i%1000 == 1)
       cout << "event " << i <<endl;
@@ -477,8 +491,9 @@ int main( int argc, char* argv[] ){
       mass = fBW->GetRandom();
     }
     h_meson_mass->Fill(mass);
-    TLorentzVector sc1P4_lab(0, 0, 0, 0);
-    TLorentzVector sc2P4_lab(0, 0, 0, 0);
+    sc1P4_lab = TLorentzVector(0, 0, 0, 0);
+    sc2P4_lab = TLorentzVector(0, 0, 0, 0);
+    
     double PhiLAB = fRandom->Uniform(-TMath::Pi(), TMath::Pi());
     TLorentzVector eta_LAB_P4 = meson_lab(ISP4, mass,  ParticleMass(t_target), ThetaLAB, PhiLAB);
     if (do_flat_qf || m_rfile.Contains("free"))
@@ -639,7 +654,7 @@ int main( int argc, char* argv[] ){
       }
     }
         
-    if (m_meson == "Rho0") {
+    if (m_meson == "Rho0" || m_meson == "Omega") {
       double m_sc1 = ParticleMass(t_sc1); // GeV
       double m_sc2 = ParticleMass(t_sc2); // GeV
       
@@ -717,7 +732,7 @@ int main( int argc, char* argv[] ){
 	//cout <<"I am here 2 "<<endl;
 	tmpEvt.q2 = He4_LAB_P4;
 	tmpEvt.nGen = 2;
-      } else if (ng_max == 0 && m_Fermi_file != "" && m_meson != "Rho0") {
+      } else if (ng_max == 0 && m_Fermi_file != "" && m_sc[0] == "") {
 	//cout <<"I am here 3 "<<endl;
 	//cout <<"part x " << ParticipantP4.X() << " y " << ParticipantP4.Y() << " z " << ParticipantP4.Z() << " e " << ParticipantP4.E() << " m " << ParticipantP4.M() << endl;
 	//cout <<"spec x " << SpectatorP4.X() << " y " << SpectatorP4.Y() << " z " << SpectatorP4.Z() << " e " << SpectatorP4.E() << " m " << SpectatorP4.M() << endl;
@@ -733,7 +748,7 @@ int main( int argc, char* argv[] ){
 	tmpEvt.t_part = t_participant;
 	tmpEvt.t_spec = t_spectator;
 	tmpEvt.nGen = 3;
-      } else if (ng_max == 0 && m_Fermi_file != "" && m_meson == "Rho0") {
+      } else if (ng_max == 0 && m_Fermi_file != "" && m_sc[0] != "" && m_sc[1] != "") {
 	//cout <<"I am here 3 "<<endl;
 	//cout <<"part x " << ParticipantP4.X() << " y " << ParticipantP4.Y() << " z " << ParticipantP4.Z() << " e " << ParticipantP4.E() << " m " << ParticipantP4.M() << endl;
 	//cout <<"spec x " << SpectatorP4.X() << " y " << SpectatorP4.Y() << " z " << SpectatorP4.Z() << " e " << SpectatorP4.E() << " m " << SpectatorP4.M() << endl;
@@ -754,7 +769,7 @@ int main( int argc, char* argv[] ){
 	tmpEvt.t_part = t_participant;
 	tmpEvt.t_spec = t_spectator;
 	tmpEvt.nGen = 4;
-      } else if (ng_max == 0 && m_Fermi_file == "" && m_meson == "Rho0") {
+      } else if (ng_max == 0 && m_Fermi_file == "" && m_sc[0] != "" && m_sc[1] != "") {
 	tmpEvt.str_decay = "decaying";
 	tmpEvt.q1 = sc1P4_lab;
 	tmpEvt.q2 = sc2P4_lab;


### PR DESCRIPTION
if ccdb is replaced by tagged-ccdb in beam.cfg, then the tagged flux is used.