### PR TITLE
Register FSRootDataReaderBootstrap in fit

### DIFF
--- a/src/programs/AmplitudeAnalysis/fit/fit.cc
+++ b/src/programs/AmplitudeAnalysis/fit/fit.cc
@@ -17,6 +17,7 @@
 #include "AMPTOOLS_DATAIO/ROOTDataReaderTEM.h"
 #include "AMPTOOLS_DATAIO/ROOTDataReaderHist.h"
 #include "AMPTOOLS_DATAIO/FSRootDataReader.h"
+#include "AMPTOOLS_DATAIO/FSRootDataReaderBootstrap.h"
 #include "AMPTOOLS_AMPS/TwoPSAngles.h"
 #include "AMPTOOLS_AMPS/TwoPSHelicity.h"
 #include "AMPTOOLS_AMPS/TwoPiAngles.h"
@@ -452,6 +453,7 @@ int main( int argc, char* argv[] ){
    AmpToolsInterface::registerDataReader( ROOTDataReaderTEM() );
    AmpToolsInterface::registerDataReader( ROOTDataReaderHist() );
    AmpToolsInterface::registerDataReader( FSRootDataReader() );
+   AmpToolsInterface::registerDataReader( FSRootDataReaderBootstrap() );
 
    // normalize seedFile file extension if not already set by user
    if (seedfile.size() != 0){

--- a/src/programs/AmplitudeAnalysis/fitMPI/fitMPI.cc
+++ b/src/programs/AmplitudeAnalysis/fitMPI/fitMPI.cc
@@ -15,6 +15,7 @@
 #include "AMPTOOLS_DATAIO/ROOTDataReaderWithTCut.h"
 #include "AMPTOOLS_DATAIO/ROOTDataReaderTEM.h"
 #include "AMPTOOLS_DATAIO/FSRootDataReader.h"
+#include "AMPTOOLS_DATAIO/FSRootDataReaderBootstrap.h"
 #include "AMPTOOLS_AMPS/TwoPSAngles.h"
 #include "AMPTOOLS_AMPS/TwoPSHelicity.h"
 #include "AMPTOOLS_AMPS/TwoPiAngles.h"
@@ -423,6 +424,7 @@ int main( int argc, char* argv[] ){
    AmpToolsInterface::registerDataReader( DataReaderMPI<ROOTDataReaderWithTCut>() );
    AmpToolsInterface::registerDataReader( DataReaderMPI<ROOTDataReaderTEM>() );
    AmpToolsInterface::registerDataReader( DataReaderMPI<FSRootDataReader>() );
+   AmpToolsInterface::registerDataReader( DataReaderMPI<FSRootDataReaderBootstrap>() );
 
    // normalize seedFile file extension if not already set by user
    if (seedfile.size() != 0){


### PR DESCRIPTION
fit and fitMPI were both missing the bootstrap version of the FSRootDataReader, and this commit successfully registers them for the program