### PR TITLE
Add options to produce a dummy fit, and loosen the error matrix requirement

### DIFF
--- a/src/programs/AmplitudeAnalysis/fit/fit.cc
+++ b/src/programs/AmplitudeAnalysis/fit/fit.cc
@@ -113,6 +113,7 @@ double runSingleFit(ConfigurationInfo* cfgInfo, bool useMinos, bool hesse, int m
 
   if( fitFailed ){
     cout << "ERROR: fit failed use results with caution..." << endl;
+    cout << "Fit status = " << fitManager->status() << ", eMatrix status = " << fitManager->eMatrixStatus() << endl;
     return 1e6;
   }
 
@@ -195,8 +196,10 @@ void runRndFits(ConfigurationInfo* cfgInfo, bool useMinos, bool hesse, int maxIt
 
     bool fitFailed = (fitManager->status() != 0 || fitManager->eMatrixStatus() < eMatrixRequirement);
 
-    if( fitFailed )
+    if( fitFailed ){
       cout << "ERROR: fit failed use results with caution..." << endl;
+      cout << "Fit status = " << fitManager->status() << ", eMatrix status = " << fitManager->eMatrixStatus() << endl;
+    }
 
     cout << "LIKELIHOOD AFTER MINIMIZATION:  " << ati.likelihood() << endl;
 
@@ -304,8 +307,10 @@ void runParScan(ConfigurationInfo* cfgInfo, bool useMinos, bool hesse, int maxIt
 
     bool fitFailed = (fitManager->status() != 0 || fitManager->eMatrixStatus() < eMatrixRequirement);
 
-    if( fitFailed )
+    if( fitFailed ){
       cout << "ERROR: fit failed use results with caution..." << endl;
+      cout << "Fit status = " << fitManager->status() << ", eMatrix status = " << fitManager->eMatrixStatus() << endl;
+    }
 
     cout << "LIKELIHOOD AFTER MINIMIZATION:  " << ati.likelihood() << endl;
 

--- a/src/programs/AmplitudeAnalysis/fit/fit.cc
+++ b/src/programs/AmplitudeAnalysis/fit/fit.cc
@@ -485,7 +485,7 @@ int main( int argc, char* argv[] ){
 
    if(noFit)
      getLikelihood(cfgInfo);
-   if(createDummyFit)
+   else if(createDummyFit)
      saveDummyFit(cfgInfo);
    else if(printAmps)
      printAmplitudes(cfgInfo);


### PR DESCRIPTION
This commit adds the arguments "-d" to produce a dummy fit result, and "-e" to change the error matrix status requirement.

Dummy `.fit` result files, or files produced without running the fit, are useful for applications where one needs a placeholder file as input for other scripts. The `.fit` file is produced using the initialized values from the `.cfg` file, so this can also be useful if a user wants to use the `FitResults` interface without having to waste computing resources running a fit to make the file.

The requirement that the error matrix is full and accurate (`eMatrixStatus == 3`) is still the default, but there are situations one may want to loosen this for testing. Since the variable is a discrete scale for how "good" the matrix is, this new argument sets the minimum value which defines a successful fit, i.e., passing `-e 1` requires that the error matrix is _at least_ approximated, but does not need to be accurate.