### PR TITLE
DeepWiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # halld_sim
-Simulation for GlueX.
+This repository is a central component of the GlueX/Hall-D experiment's software stack. It provides the infrastructure for simulating physics processes, detector response, and data acquisition (DAQ) behavior. The repository manages the transition from theoretical event generation to digitized detector hits that mimic real experimental data.
 
 See the [Offline Software Wiki Page](https://halldweb.jlab.org/wiki/index.php/GlueX_Offline_Software#Software_Packages) for more information.
 
-Contains programs used to do detector simulation and event generation.
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/JeffersonLab/halld_sim)
 


### PR DESCRIPTION
links DeepWiki documentation to GitHub repository and enables automatic indexing