### PR TITLE
Small bug fix in FitConverter

### DIFF
--- a/src/libraries/UTILITIES/AmplitudeParser.h
+++ b/src/libraries/UTILITIES/AmplitudeParser.h
@@ -38,15 +38,15 @@
 /**
  * @class AmplitudeParser
  * @brief Parses amplitude names and builds coherent sums based on naming schemes
- * 
+ *
  * This class is responsible for parsing amplitude names from AmpTools fit results and
- * grouping them into coherent sums based on shared quantum numbers. It supports 
- * multiple naming schemes, which can be selected by the user or inferred from the 
- * amplitude labels. The parser identifies the relevant quantum numbers from the 
- * amplitude names and groups amplitudes that share those quantum numbers into sums, 
- * which can then be used to calculate intensities of sums e.g. total reflectivity 
- * contributions, or total spin contributions. 
- * 
+ * grouping them into coherent sums based on shared quantum numbers. It supports
+ * multiple naming schemes, which can be selected by the user or inferred from the
+ * amplitude labels. The parser identifies the relevant quantum numbers from the
+ * amplitude names and groups amplitudes that share those quantum numbers into sums,
+ * which can then be used to calculate intensities of sums e.g. total reflectivity
+ * contributions, or total spin contributions.
+ *
  * @note All amplitudes that match the criteria for a sum group will be included,
  * meaning amplitudes will be gathered across reactions and sums as long as they share
  * the relevant quantum numbers based on the selected naming scheme. For example, if we
@@ -56,7 +56,7 @@
  * - "reaction2::sum1::p1ppS"
  * Then all three of these amplitudes would be included in the same sum group "JPL"
  * because they all share the same J, P, and L values.
- * 
+ *
  */
 class AmplitudeParser
 {

--- a/src/libraries/UTILITIES/FitConverter.cc
+++ b/src/libraries/UTILITIES/FitConverter.cc
@@ -205,7 +205,7 @@ std::set<std::string> FitConverter::uniqueSumAmpNames() const
         size_t last_colon = amplitude.rfind("::");
         if (first_colon != std::string::npos && last_colon != std::string::npos && first_colon != last_colon)
         {
-            std::string sum_amp_name = amplitude.substr(first_colon + 2, last_colon - first_colon - 2);
+            std::string sum_amp_name = amplitude.substr(first_colon + 2);
             unique_names.insert(sum_amp_name);
         }
     }

--- a/src/libraries/UTILITIES/RootDataConverter.cc
+++ b/src/libraries/UTILITIES/RootDataConverter.cc
@@ -187,7 +187,6 @@ std::string RootDataConverter::getCSVRow() const
     return row;
 }
 
-
 std::vector<std::string> RootDataConverter::findFiles(const std::string &file_type) const
 {
     std::vector<std::string> files;

--- a/src/libraries/UTILITIES/RootDataConverter.h
+++ b/src/libraries/UTILITIES/RootDataConverter.h
@@ -42,17 +42,17 @@
  * std::ofstream csv_file(output_file);
  * std::stringstream csv_data;
  * bool header_written = false;
- * 
+ *
  * for (const auto& file : input_files) {
  *    RootDataConverter converter(file);
- * 
+ *
  *    if (!header_written) {
  *        csv_data << converter.getCSVHeader() << "\n";
  *        header_written = true;
  *    }
  *    csv_data << converter.getCSVRow() << "\n";
  * }
- * 
+ *
  * csv_file << csv_data.str();
  * csv_file.close();
  * @endcode
@@ -129,24 +129,24 @@ public:
 
     /**
      * @brief Get the CSV header row
-     * 
+     *
      * Constructs a comma-separated header string based on the keys of the m_values map.
-     * 
+     *
      * @note It is crucial that the order of entries in the header matches the order of
      * values in getCSVRow().
-     * 
+     *
      * @return std::string Comma-separated header string
      */
     std::string getCSVHeader() const;
 
     /**
      * @brief Get the CSV row
-     * 
+     *
      * Constructs a comma-separated row string based on the values of the m_values map.
-     * 
+     *
      * @note It is crucial that the order of values in this row matches the order of
      * entries in getCSVHeader().
-     * 
+     *
      * @return std::string Comma-separated row string
      */
     std::string getCSVRow() const;
@@ -190,7 +190,7 @@ public:
     void validateDataFiles() const { validateFiles(m_data_files, "data"); }
     /**
      * @brief Validate that background files were found
-     * 
+     *
      * If no background files are found, it will warn the user and assume that weights
      * are stored directly in the data tree.
      */
@@ -445,11 +445,11 @@ private:
 
     /**
      * @brief Calculate the acceptance-corrected number of events and associated error
-     * 
+     *
      * @param events total number of events. See numberOfEvents.
      * @param events_err error on total number of events. See numberOfEvents.
      * @param efficiency acceptance efficiency. See efficiency().
-     * @return std::pair<double, double> acceptance-corrected number of events and 
+     * @return std::pair<double, double> acceptance-corrected number of events and
      * associated error
      */
     std::pair<double, double> acceptanceCorrectedEvents(double events, double events_err, double efficiency) const;

--- a/src/programs/AmplitudeAnalysis/convert_to_csv/convert_to_csv.cc
+++ b/src/programs/AmplitudeAnalysis/convert_to_csv/convert_to_csv.cc
@@ -11,7 +11,7 @@
  * naming schemes, which it uses to group amplitudes into coherent sums based on shared
  * quantum numbers. The output CSV files can then be easily imported into just about any
  * data analysis or plotting software.
- * 
+ *
  * Print the help message with
  * @verbatim
  * user@host:~$ convert_to_csv -h
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
 
     auto print_help = []()
     {
-        report(INFO, kModule) << "Usage: convert_to_csv [-h] [-i INPUT_FILES] [-o OUTPUT_PATH] [-s] [--sort-index INDEX] [-a] [-d] [-l LOWER_VERTEX_INDICES] [-n NAMING_SCHEME] [-p] [-v] [--correlation] [--covariance] [--norm-int] \n";                
+        report(INFO, kModule) << "Usage: convert_to_csv [-h] [-i INPUT_FILES] [-o OUTPUT_PATH] [-s] [--sort-index INDEX] [-a] [-d] [-l LOWER_VERTEX_INDICES] [-n NAMING_SCHEME] [-p] [-v] [--correlation] [--covariance] [--norm-int] \n";
         report(INFO, kModule) << "  -i INPUT_FILES:\t\tFull path to the .fit file(s)\n";
         report(INFO, kModule) << "  -o OUTPUT_PATH:\t\tFull path to the output .csv file\n";
         report(INFO, kModule) << "  -s, --sort:\t\t\tSort files by last number in the file name or path (default:true)\n";
@@ -261,7 +261,7 @@ int main(int argc, char *argv[])
     std::stringstream csv_result_data, csv_cov_data, csv_corr_data, csv_norm_int_data, csv_root_data;
     bool header_written = false;
     std::string first_file_result_header, first_file_cov_header, first_file_corr_header, first_file_norm_int_header, first_file_data_header;
-    
+
     for (const auto &file : input_files)
     {
         if (verbose)
@@ -316,9 +316,9 @@ int main(int argc, char *argv[])
             }
         }
         else
-        { 
+        {
             // this block ensures all files have the same csv header format. If this is
-            // not the case, then the csv files will be malformed and difficult to work 
+            // not the case, then the csv files will be malformed and difficult to work
             // with, so we enforce that here before processing any files
             std::string header = converter.getCSVHeader();
             if (header != first_file_result_header)
@@ -393,11 +393,10 @@ int main(int argc, char *argv[])
     result_file << csv_result_data.str();
     result_file.close();
 
-    // covariance and correlation matrix files are written to separate files in the same
-    // directory as the main output file, with suffixes _covariance.csv and 
-    // _correlation.csv
+    // supplemental files are written to separate files in the same directory as the
+    // main output file, with appropriate suffixes e.g. "_data.csv", "correlation.csv"
     if (create_covariance)
-    {        
+    {
         std::filesystem::path output_path(output_file);
         std::string covariance_file = (output_path.parent_path() / (output_path.stem().string() + "_covariance.csv")).string();
         std::ofstream cov_file(covariance_file);


### PR DESCRIPTION
This addresses the issue raised in @lihaoahil 's [comment from the original pull request](https://github.com/JeffersonLab/halld_sim/pull/393#issuecomment-4879338622). The issue was because of a mistake in the `uniqueSumAmpNames` function, where only the `sum` in `reaction::sum::amp` was being extracted, instead of the intended `sum::amp`. 

I ran
```
convert_to_csv -i /w/halld-scshelf2101/home/haoli/analysis/testIO_kpi/test_Kevin/doubleSDME.fit -o test.csv > output.txt
```
I've attached the debug output and csv file below for reference.

[output.txt](https://github.com/user-attachments/files/29793622/output.txt)
[test.csv](https://github.com/user-attachments/files/29793623/test.csv)

Aside from this, small formatting changes were made, and an outdated comment was edited.