### PR TITLE
Switch from rapidjson to tao syntax

### DIFF
--- a/src/programs/Simulation/mcsmear/mcsmear_config.cc
+++ b/src/programs/Simulation/mcsmear/mcsmear_config.cc
@@ -134,7 +134,7 @@ bool mcsmear_config_t::ParseRCDBConfigFile(int runNumber)
     }
 
     auto json = rtvsCondition->ToJsonDocument();               // The CODA rtvs is serialized as JSon dictionary.
-    string fileName(json["%(config)"].GetString());            // The file name is stored in '%(config)'
+    string fileName(json.at("%(config)").get_string());        // The file name is stored in '%(config)'
 
 
     // Get file out of RCDB (indexed by run number and name)


### PR DESCRIPTION
this change was introduced in rcdb v2.4.0 and is not backward compatible
-> the PR test fails